### PR TITLE
Explicit permissions to GitHub workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  pull-requests: write
 
 jobs:
   docker-lint:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,11 +4,10 @@ on:
   pull_request:
     types: [synchronize, opened, reopened]
 
-# Add permissions block to limit workflow access
+
+# Set minimum permissions by default
 permissions:
   contents: read
-  security-events: write
-  pull-requests: write
 
 jobs:
   docker-lint:
@@ -26,6 +25,10 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Specify permissions needed for this job
+    permissions:
+      security-events: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [synchronize, opened, reopened]
 
+# Add permissions block to limit workflow access
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   docker-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added a permissions block to the code-quality.yml workflow that limits the workflow's access to only what it needs:
- Read access to repository contents
- Write access to security events for scan results

This follows the principle of least privilege and improves overall security.