### PR TITLE
Add commit and PR formatting rules

### DIFF
--- a/.cursor/rules/commit-message-rules.mdc
+++ b/.cursor/rules/commit-message-rules.mdc
@@ -28,14 +28,23 @@ Add user authentication to login page
 ```
 
 ## Git Command Format
-When using the git commit command, use a single `-m` flag with properly formatted message including title, blank line, and bullet points:
+To create a commit with proper line breaks, use the text editor method instead of inline -m flags:
 
 ```
-git commit -m "Title
+# This opens your default text editor where you can properly format the message
+git commit
+```
+
+Alternatively, you can use heredoc syntax in the shell:
+
+```
+git commit -F- << EOF
+Title
 
 - Item 1
 - Item 2
-- Item 3"
+- Item 3
+EOF
 ```
 
 ## Process

--- a/.cursor/rules/commit-message-rules.mdc
+++ b/.cursor/rules/commit-message-rules.mdc
@@ -15,7 +15,7 @@ When creating a commit, follow these guidelines:
 ## Commit Message Format
 - Title: One sentence summary (max 120 characters)
 - Empty line
-- Body: Bullet list of changes
+- Body: Bullet list of changes (with NO extra lines between bullet points)
 - No additional text
 
 ## Example:
@@ -25,6 +25,15 @@ Add user authentication to login page
 - Add password validation function
 - Create JWT token generation
 - Add error handling for invalid credentials
+```
+
+## Git Command Format
+When using the git commit command, use a single `-m` flag for the title and a single `-m` flag for the entire bullet list:
+
+```
+git commit -m "Title" -m "- Item 1
+- Item 2
+- Item 3"
 ```
 
 ## Process

--- a/.cursor/rules/commit-message-rules.mdc
+++ b/.cursor/rules/commit-message-rules.mdc
@@ -28,10 +28,12 @@ Add user authentication to login page
 ```
 
 ## Git Command Format
-When using the git commit command, use a single `-m` flag for the title and a single `-m` flag for the entire bullet list:
+When using the git commit command, use a single `-m` flag with properly formatted message including title, blank line, and bullet points:
 
 ```
-git commit -m "Title" -m "- Item 1
+git commit -m "Title
+
+- Item 1
 - Item 2
 - Item 3"
 ```

--- a/.cursor/rules/commit-message-rules.mdc
+++ b/.cursor/rules/commit-message-rules.mdc
@@ -1,0 +1,34 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Commit Message Guidelines
+
+When creating a commit, follow these guidelines:
+
+## Analysis Process
+1. Run `git --no-pager status` to see which files have changed
+2. Run `git --no-pager diff` to see the actual changes in the code
+3. Analyze the changes to understand the purpose and impact
+
+## Commit Message Format
+- Title: One sentence summary (max 120 characters)
+- Empty line
+- Body: Bullet list of changes
+- No additional text
+
+## Example:
+```
+Add user authentication to login page
+
+- Add password validation function
+- Create JWT token generation
+- Add error handling for invalid credentials
+```
+
+## Process
+1. Analyze changes
+2. Create commit message following the format
+3. Commit the changes
+4. Push to remote repository

--- a/.cursor/rules/pull-request-rules.mdc
+++ b/.cursor/rules/pull-request-rules.mdc
@@ -16,7 +16,7 @@ When creating or updating a pull request, follow these guidelines:
 
 ## Pull Request Format
 - Title: One sentence summary (max 120 characters)
-- Body: Bullet list of changes only
+- Body: Bullet list of changes only (with NO extra lines between bullet points)
 - No additional text or explanations
 
 ## Example:
@@ -27,6 +27,11 @@ Add user authentication to login page
 - Create JWT token generation
 - Add error handling for invalid credentials
 ```
+
+## PR Description Formatting
+When creating a PR, ensure that all bullet points are written without extra lines between them.
+In GitHub or similar platforms, preview the PR description to verify there are no unwanted
+line breaks between bullet points.
 
 ## Process
 1. Analyze changes between main and current branch

--- a/.cursor/rules/pull-request-rules.mdc
+++ b/.cursor/rules/pull-request-rules.mdc
@@ -1,0 +1,35 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+Rule Name: pull-request-rules
+Description: 
+# Pull Request Guidelines
+
+When creating or updating a pull request, follow these guidelines:
+
+## Analysis Process
+1. Run `git --no-pager status` to see which files have changed
+2. Run `git --no-pager diff` to compare the current branch with main
+3. Analyze the changes to understand the purpose and impact
+
+## Pull Request Format
+- Title: One sentence summary (max 120 characters)
+- Body: Bullet list of changes only
+- No additional text or explanations
+
+## Example:
+```
+Add user authentication to login page
+
+- Add password validation function
+- Create JWT token generation
+- Add error handling for invalid credentials
+```
+
+## Process
+1. Analyze changes between main and current branch
+2. Create PR title and bullet list description
+3. Create new PR or update existing PR tied to current branch
+4. Request review if needed


### PR DESCRIPTION
Add commit and PR formatting rules

- Add pull request guidelines with clear bullet point formatting instructions
- Add commit message guidelines with proper line break methods
- Implement heredoc syntax method for shell-based commits
