### PR TITLE
Add CODEOWNERS file to set default code reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # affecting any file in the repository
 
 # Default owner for everything in the repo
-*       @killev 
+*       @killev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This is a CODEOWNERS file for the repository
+# @killev will be requested for review when someone opens a pull request
+# affecting any file in the repository
+
+# Default owner for everything in the repo
+*       @killev 


### PR DESCRIPTION
This PR adds a CODEOWNERS file to automatically assign @killev as the default reviewer for all pull requests.