### PR TITLE
refactor: Improve case study card styles with text truncation mixin

### DIFF
--- a/website/modules/asset/ui/src/scss/_buttons.scss
+++ b/website/modules/asset/ui/src/scss/_buttons.scss
@@ -9,7 +9,6 @@
   box-shadow: none;
   background-color: $gray-500;
   padding: 12px;
-  font-size: $font-size-body-medium-mobile;
   font-style: $font-style-normal;
   font-weight: $font-weight-extra-bold;
   line-height: 0.8;
@@ -25,9 +24,9 @@
   min-width: 0;
   max-width: 270px;
   text-align: center;
+  @include responsive-font(14px, 20px);
 
   @include breakpoint-medium {
-    font-size: $font-size-body-large;
     padding: 24px 92px;
     height: 64px;
     max-width: initial;
@@ -131,6 +130,7 @@
     background: $gray-300;
     border: none;
     opacity: 0.5;
+    overflow: initial;
     cursor: not-allowed;
 
     &:hover {

--- a/website/modules/asset/ui/src/scss/_cases.scss
+++ b/website/modules/asset/ui/src/scss/_cases.scss
@@ -2,7 +2,6 @@
   &_container {
     max-width: 1440px;
     margin: 0 auto;
-    padding: 2rem;
   }
 
   &_content {
@@ -72,79 +71,6 @@
     @include breakpoint-medium {
       flex-direction: row;
     }
-  }
-
-  &_grid {
-    display: grid;
-    gap: 1rem;
-    margin: 1rem;
-    grid-template-columns: minmax(280px, 1fr);
-    justify-content: center;
-
-    @include breakpoint-medium {
-      grid-template-columns: repeat(2, minmax(300px, 500px));
-      gap: 2rem;
-      margin: 2rem 5rem;
-    }
-  }
-
-  &_card {
-    border: 1px solid $gray-300;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    padding: 20px;
-    background: $gray-100;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    transition:
-      transform 0.2s,
-      box-shadow 0.2s;
-    text-decoration: none;
-    color: inherit;
-
-    &:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
-    }
-  }
-
-  &_image {
-    width: 100%;
-    height: 200px;
-    object-fit: cover;
-  }
-
-  &_details {
-    padding: 1.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  &_title {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: $gray-500;
-    margin: 0;
-  }
-
-  &_author {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: $gray-300;
-    font-size: 0.875rem;
-  }
-
-  &_name {
-    font-weight: 500;
-  }
-
-  &_summary {
-    color: $gray-300;
-    font-size: 0.875rem;
-    line-height: 1.5;
-    margin: 0;
   }
 }
 
@@ -285,43 +211,152 @@
 }
 
 .cs_card {
-  background-color: #fff;
+  background-color: $white;
   border: 1px solid $whisper;
-  border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  text-decoration: none;
 
   &:hover {
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 4px 16px rgba($black, 0.15);
   }
-}
 
-.placeholder-image-container {
-  width: 100%;
-  height: 200px;
-  overflow: hidden;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: #f4f4f4;
-}
+  .image {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    height: auto;
+    max-height: 140px;
+    object-fit: cover;
 
-.placeholder-image {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: cover;
-}
+    @include breakpoint-large {
+      width: 437px;
+      max-height: 240px;
+    }
+  }
 
-.cs_details {
-  padding: 16px;
-}
+  .placeholder-image-container {
+    width: 100%;
+    height: 200px;
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba($gray-400, 0.5);
 
-.client-name {
-  font-size: 1.2rem;
-  font-weight: bold;
-  color: #333;
-  margin: 0;
-  line-height: 1.4;
+    @include breakpoint-large {
+      align-items: flex-start;
+      padding-top: 35px;
+    }
+  }
+
+  .placeholder-image {
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  .cs_details {
+    background: $white;
+    padding: 24px;
+
+    @include breakpoint-large {
+      width: 397px;
+      height: 195px;
+      margin: -94px auto 0;
+    }
+
+    .cname {
+      @include responsive-font(16px, 22px);
+      @include responsive-line-height(150%, 110%);
+      font-style: $font-style-normal;
+      font-weight: $font-weight-extra-bold;
+      color: $gray-500;
+      margin: 0 0 4px;
+      max-width: 274px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      height: 24px;
+
+      @include breakpoint-large {
+        max-width: 349px;
+      }
+    }
+
+    .type {
+      @include responsive-font(10px, 10px);
+      @include responsive-line-height(140%, 140%);
+      color: $gray-300;
+      font-style: $font-style-normal;
+      font-weight: $font-weight-extra-bold;
+      max-width: 274px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-bottom: 12px;
+      height: 14px;
+
+      @include breakpoint-large {
+        max-width: 349px;
+      }
+    }
+
+    .industry {
+      @include responsive-font(10px, 10px);
+      @include responsive-line-height(140%, 140%);
+      font-style: $font-style-normal;
+      font-weight: $font-weight-medium;
+      color: $gray-300;
+      max-width: 274px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-bottom: 4px;
+      height: 14px;
+
+      @include breakpoint-large {
+        max-width: 349px;
+      }
+    }
+
+    .portfolio-title {
+      @include responsive-font(14px, 14px);
+      @include responsive-line-height(150%, 150%);
+      font-style: $font-style-normal;
+      font-weight: $font-weight-medium;
+      color: $gray-500;
+      max-width: 274px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin: 0 0 16px;
+      height: 42px;
+
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+
+      @include breakpoint-large {
+        max-width: 349px;
+      }
+    }
+
+    .stack {
+      @include responsive-font(11px, 11px);
+      @include responsive-line-height(120%, 120%);
+      font-style: $font-style-normal;
+      font-weight: $font-weight-300;
+      color: $gray-300;
+      max-width: 274px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      height: 13px;
+
+      @include breakpoint-large {
+        max-width: 349px;
+      }
+    }
+  }
 }

--- a/website/modules/asset/ui/src/scss/_cases.scss
+++ b/website/modules/asset/ui/src/scss/_cases.scss
@@ -272,3 +272,56 @@
     margin-bottom: 80px;
   }
 }
+
+// Case Study card
+.cs_grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+
+  @include breakpoint-medium {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.cs_card {
+  background-color: #fff;
+  border: 1px solid $whisper;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  &:hover {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  }
+}
+
+.placeholder-image-container {
+  width: 100%;
+  height: 200px;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #f4f4f4;
+}
+
+.placeholder-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: cover;
+}
+
+.cs_details {
+  padding: 16px;
+}
+
+.client-name {
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: #333;
+  margin: 0;
+  line-height: 1.4;
+}

--- a/website/modules/asset/ui/src/scss/_cases.scss
+++ b/website/modules/asset/ui/src/scss/_cases.scss
@@ -204,6 +204,7 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 32px;
+  margin: 0 auto;
 
   @include breakpoint-medium {
     grid-template-columns: repeat(2, 1fr);
@@ -213,7 +214,6 @@
 .cs_card {
   background-color: $white;
   border: 1px solid $whisper;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -221,6 +221,10 @@
 
   &:hover {
     box-shadow: 0 4px 16px rgba($black, 0.15);
+  }
+
+  @include breakpoint-large {
+    border: none;
   }
 
   .image {
@@ -270,93 +274,50 @@
     .cname {
       @include responsive-font(16px, 22px);
       @include responsive-line-height(150%, 110%);
+      @include text-truncate($height: 24px);
       font-style: $font-style-normal;
       font-weight: $font-weight-extra-bold;
       color: $gray-500;
       margin: 0 0 4px;
-      max-width: 274px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      height: 24px;
-
-      @include breakpoint-large {
-        max-width: 349px;
-      }
     }
 
     .type {
       @include responsive-font(10px, 10px);
       @include responsive-line-height(140%, 140%);
+      @include text-truncate($height: 14px);
       color: $gray-300;
       font-style: $font-style-normal;
       font-weight: $font-weight-extra-bold;
-      max-width: 274px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
       margin-bottom: 12px;
-      height: 14px;
-
-      @include breakpoint-large {
-        max-width: 349px;
-      }
     }
 
     .industry {
       @include responsive-font(10px, 10px);
       @include responsive-line-height(140%, 140%);
+      @include text-truncate($height: 14px);
       font-style: $font-style-normal;
       font-weight: $font-weight-medium;
       color: $gray-300;
-      max-width: 274px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
       margin-bottom: 4px;
-      height: 14px;
-
-      @include breakpoint-large {
-        max-width: 349px;
-      }
     }
 
     .portfolio-title {
       @include responsive-font(14px, 14px);
       @include responsive-line-height(150%, 150%);
+      @include text-truncate($height: 42px, $is-multiline: true);
       font-style: $font-style-normal;
       font-weight: $font-weight-medium;
       color: $gray-500;
-      max-width: 274px;
-      overflow: hidden;
-      text-overflow: ellipsis;
       margin: 0 0 16px;
-      height: 42px;
-
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-
-      @include breakpoint-large {
-        max-width: 349px;
-      }
     }
 
     .stack {
       @include responsive-font(11px, 11px);
       @include responsive-line-height(120%, 120%);
+      @include text-truncate($height: 13px);
       font-style: $font-style-normal;
       font-weight: $font-weight-300;
       color: $gray-300;
-      max-width: 274px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      height: 13px;
-
-      @include breakpoint-large {
-        max-width: 349px;
-      }
     }
   }
 }

--- a/website/modules/asset/ui/src/scss/_mixins.scss
+++ b/website/modules/asset/ui/src/scss/_mixins.scss
@@ -130,3 +130,28 @@
     }
   }
 }
+
+// Text truncation mixin
+@mixin text-truncate(
+  $max-width: 274px,
+  $large-max-width: 349px,
+  $is-multiline: false,
+  $height: auto
+) {
+  max-width: $max-width;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  height: $height;
+
+  @if $is-multiline {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  } @else {
+    white-space: nowrap;
+  }
+
+  @include breakpoint-large {
+    max-width: $large-max-width;
+  }
+}

--- a/website/modules/asset/ui/src/scss/_mixins.scss
+++ b/website/modules/asset/ui/src/scss/_mixins.scss
@@ -22,6 +22,14 @@
   }
 }
 
+@mixin responsive-line-height($mobile-line-height, $desktop-line-height) {
+  line-height: $mobile-line-height;
+
+  @include breakpoint-medium {
+    line-height: $desktop-line-height;
+  }
+}
+
 @mixin breakpoint-extra-small {
   @media (min-width: $breakpoint-extra-small) {
     @content;

--- a/website/modules/asset/ui/src/scss/_mixins.scss
+++ b/website/modules/asset/ui/src/scss/_mixins.scss
@@ -14,6 +14,14 @@
   @include font-settings($size, $line-height, $font-weight-body);
 }
 
+@mixin responsive-font($mobile-size, $desktop-size) {
+  font-size: $mobile-size;
+
+  @include breakpoint-medium {
+    font-size: $desktop-size;
+  }
+}
+
 @mixin breakpoint-extra-small {
   @media (min-width: $breakpoint-extra-small) {
     @content;

--- a/website/modules/asset/ui/src/scss/_variables.scss
+++ b/website/modules/asset/ui/src/scss/_variables.scss
@@ -13,6 +13,7 @@ $red: #f3949c;
 $whisper: #e7e7e7;
 
 // Font weights
+$font-weight-300: 300;
 $font-weight-normal: 400;
 $font-weight-medium: 500;
 $font-weight-bold: 600;

--- a/website/modules/asset/ui/src/scss/_variables.scss
+++ b/website/modules/asset/ui/src/scss/_variables.scss
@@ -10,6 +10,7 @@ $gray-500: #191919; // Very Dark Gray
 $gray-600: #060b05;
 $black: #000000; // Black
 $red: #f3949c;
+$whisper: #e7e7e7;
 
 // Font weights
 $font-weight-normal: 400;

--- a/website/modules/case-studies-page/views/index.html
+++ b/website/modules/case-studies-page/views/index.html
@@ -59,15 +59,18 @@ data.piecesFilters.tags %} {% block main %}
         <a href="{{ article._url }}" class="cs_card">
           {% set picture = apos.image.first(article.picture) %} {% if picture is
           defined %}
+
           <img
-            class="cs_image"
+            class="image"
             loading="lazy"
             src="{{ apos.attachment.url(picture, { size: data.options.size or 'full' }) }}"
             alt="{{ picture._alt or '' }}"
             width="{{ apos.attachment.getWidth(picture) }}"
             height="{{ apos.attachment.getHeight(picture) }}"
           />
+
           {% else %}
+
           <div class="placeholder-image-container">
             <img
               class="placeholder-image"
@@ -78,18 +81,20 @@ data.piecesFilters.tags %} {% block main %}
               height="50"
             />
           </div>
+
           {% endif %}
           <div class="cs_details">
-            <h3 class="cs_title">{{ article.title }}</h3>
+            <h3 class="cname">{{ article.title }}</h3>
+            <div class="type">Mobile Development</div>
+            <div class="industry">Manufacturing</div>
+
             {% if article.portfolioTitle %}
-            <h4 class="cs_portfolio-title">{{ article.portfolioTitle }}</h4>
-            {% endif %} {% if article.descriptor %}
-            <p class="cs_descriptor">{{ article.descriptor }}</p>
+
+            <h4 class="portfolio-title">{{ article.portfolioTitle }}</h4>
+
             {% endif %} {% if article.stack %}
-            <div class="cs_stack">
-              <span class="stack-label">Tech Stack:</span>
-              <span class="stack-value">{{ article.stack }}</span>
-            </div>
+
+            <div class="stack">{{ article.stack }}</div>
 
             {% endif %}
           </div>


### PR DESCRIPTION
- Create reusable text-truncate mixin in _mixins.scss
- Replace repetitive text truncation styles with mixin in case study cards
- Add margin to cards container and remove box-shadow from cards
- Remove border on large screens for case study cards

This refactoring improves code maintainability by eliminating repetitive CSS and enhancing the responsive design of case study cards.
