### PR TITLE
fix: LocalStack S3 image loading in browser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,14 @@ services:
     environment:
       - SERVICES=s3
       - DEBUG=1
-      - DATA_DIR=/tmp/localstack/data
+      - PERSISTENCE=1
       - DOCKER_HOST=unix:///var/run/docker.sock
       - AWS_DEFAULT_REGION=us-east-1
       - HOSTNAME_EXTERNAL=localstack
       - BUCKET_NAME=apostrophe-test-bucket
       - REGION=us-east-1
     volumes:
-      - localstack-data:/tmp/localstack
+      - localstack-data:/var/lib/localstack
       - ./init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh
     networks:
       - proxynet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - DOCKER_HOST=unix:///var/run/docker.sock
       - AWS_DEFAULT_REGION=us-east-1
       - HOSTNAME_EXTERNAL=localstack
+      - BUCKET_NAME=apostrophe-test-bucket
+      - REGION=us-east-1
     volumes:
       - localstack-data:/tmp/localstack
       - ./init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh
@@ -44,6 +46,11 @@ services:
       - APOS_S3_SECRET=${APOS_S3_SECRET:-test}
       # Support for custom S3 endpoint (LocalStack)
       - APOS_S3_ENDPOINT=${APOS_S3_ENDPOINT:-http://localstack:4566}
+      - APOS_S3_PATH_STYLE=${APOS_S3_PATH_STYLE:-true}
+      # Fix for URL generation in HTML
+      - APOS_UPLOADS_URL=${APOS_UPLOADS_URL:-http://localstack:4566/apostrophe-test-bucket}
+      # Public URL for browser access (must use localhost, not container name)
+      - APOS_UPLOADS_PUBLIC_URL=${APOS_UPLOADS_PUBLIC_URL:-http://localhost:4566/apostrophe-test-bucket}
       # CDN setting loaded from .env file
       - APOS_CDN_URL=${APOS_CDN_URL:-}
       - APOS_CDN_ENABLED=${APOS_CDN_ENABLED:-false}
@@ -51,6 +58,7 @@ services:
     command: ["npm", "start"]
     depends_on:
       - mongodb
+      - localstack
     restart: unless-stopped
     healthcheck:
       test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,30 +3,43 @@ networks:
     name: sf-website-development
 
 services:
-  localstack:
-    image: localstack/localstack:2.2
-    container_name: apostrophe-localstack
+  minio:
+    image: minio/minio:latest
+    container_name: apostrophe-minio
     ports:
-      - "4566:4566"
+      - "9000:9000"  # API port
+      - "9001:9001"  # Console port
     environment:
-      - SERVICES=s3
-      - DEBUG=1
-      - PERSISTENCE=1
-      - DOCKER_HOST=unix:///var/run/docker.sock
-      - AWS_DEFAULT_REGION=us-east-1
-      - HOSTNAME_EXTERNAL=localstack
-      - BUCKET_NAME=apostrophe-test-bucket
-      - REGION=us-east-1
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=minio123
     volumes:
-      - localstack-data:/var/lib/localstack
-      - ./init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh
+      - minio-data:/data
+    command: server --console-address :9001 /data
     networks:
       - proxynet
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localstack:4566/_localstack/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s
       timeout: 5s
       retries: 3
+
+  # MinIO setup helper - creates bucket and configures policies
+  minio-setup:
+    image: minio/mc
+    container_name: apostrophe-minio-setup
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5;
+      /usr/bin/mc config host add myminio http://minio:9000 minio minio123;
+      /usr/bin/mc mb myminio/apostrophe-test-bucket --ignore-existing;
+      /usr/bin/mc anonymous set download myminio/apostrophe-test-bucket;
+      exit 0;
+      "
+    networks:
+      - proxynet
+
   # Apostrophe CMS web application
   apostrophe:
     build:
@@ -39,18 +52,18 @@ services:
       - NODE_ENV=development
       - APOS_MONGODB_URI=mongodb://mongodb:27017/apostrophe
       - SESSION_SECRET=change_this_to_a_secure_secret
-      # AWS S3 settings loaded from .env file
+      # S3 settings for MinIO
       - APOS_S3_BUCKET=${APOS_S3_BUCKET:-apostrophe-test-bucket}
       - APOS_S3_REGION=${APOS_S3_REGION:-us-east-1}
-      - APOS_S3_KEY=${APOS_S3_KEY:-test}
-      - APOS_S3_SECRET=${APOS_S3_SECRET:-test}
-      # Support for custom S3 endpoint (LocalStack)
-      - APOS_S3_ENDPOINT=${APOS_S3_ENDPOINT:-http://localstack:4566}
+      - APOS_S3_KEY=${APOS_S3_KEY:-minio}
+      - APOS_S3_SECRET=${APOS_S3_SECRET:-minio123}
+      # MinIO endpoint
+      - APOS_S3_ENDPOINT=${APOS_S3_ENDPOINT:-http://minio:9000}
       - APOS_S3_PATH_STYLE=${APOS_S3_PATH_STYLE:-true}
       # Fix for URL generation in HTML
-      - APOS_UPLOADS_URL=${APOS_UPLOADS_URL:-http://localstack:4566/apostrophe-test-bucket}
+      - APOS_UPLOADS_URL=${APOS_UPLOADS_URL:-http://minio:9000/apostrophe-test-bucket}
       # Public URL for browser access (must use localhost, not container name)
-      - APOS_UPLOADS_PUBLIC_URL=${APOS_UPLOADS_PUBLIC_URL:-http://localhost:4566/apostrophe-test-bucket}
+      - APOS_UPLOADS_PUBLIC_URL=${APOS_UPLOADS_PUBLIC_URL:-http://localhost:9000/apostrophe-test-bucket}
       # CDN setting loaded from .env file
       - APOS_CDN_URL=${APOS_CDN_URL:-}
       - APOS_CDN_ENABLED=${APOS_CDN_ENABLED:-false}
@@ -58,7 +71,8 @@ services:
     command: ["npm", "start"]
     depends_on:
       - mongodb
-      - localstack
+      - minio
+      - minio-setup
     restart: unless-stopped
     healthcheck:
       test:
@@ -136,4 +150,4 @@ services:
 volumes:
   mongodb_data:
   redis_data:
-  localstack-data:
+  minio-data:

--- a/init-localstack.sh
+++ b/init-localstack.sh
@@ -25,9 +25,11 @@ done
 
 echo "LocalStack is ready!"
 
-# Remove bucket if it exists
-echo "Removing existing bucket if it exists..."
-awslocal s3 rb s3://$BUCKET_NAME --force || true
+# Check if bucket already exists
+if awslocal s3 ls "s3://$BUCKET_NAME" > /dev/null 2>&1; then
+  echo "Bucket $BUCKET_NAME already exists. Skipping setup."
+  exit 0
+fi
 
 # Create the bucket
 echo "Creating S3 bucket: $BUCKET_NAME"

--- a/init-localstack.sh
+++ b/init-localstack.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# Use environment variables from Docker Compose
+# If not set, use defaults
+BUCKET_NAME=${BUCKET_NAME:-"apostrophe-test-bucket"}
+REGION=${REGION:-"us-east-1"}
+
+echo "Starting S3 bucket initialization..."
+echo "Using bucket name: $BUCKET_NAME"
+echo "Using region: $REGION"
+
+# Wait for LocalStack to be fully running
+echo "Waiting for LocalStack to be ready..."
+MAX_ATTEMPTS=30
+ATTEMPT=0
+until awslocal s3 ls > /dev/null 2>&1; do
+  ATTEMPT=$((ATTEMPT+1))
+  if [ $ATTEMPT -gt $MAX_ATTEMPTS ]; then
+    echo "LocalStack failed to start after $MAX_ATTEMPTS attempts. Exiting."
+    exit 1
+  fi
+  echo "LocalStack not ready yet... (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+  sleep 2
+done
+
+echo "LocalStack is ready!"
+
+# Remove bucket if it exists
+echo "Removing existing bucket if it exists..."
+awslocal s3 rb s3://$BUCKET_NAME --force || true
+
+# Create the bucket
+echo "Creating S3 bucket: $BUCKET_NAME"
+if ! awslocal s3 mb s3://$BUCKET_NAME --region $REGION; then
+  echo "Failed to create bucket. Exiting."
+  exit 1
+fi
+
+# Set the bucket to allow public access
+echo "Making bucket publicly accessible..."
+if ! awslocal s3api put-public-access-block --bucket $BUCKET_NAME --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"; then
+  echo "Warning: Failed to set public access block configuration"
+fi
+
+# Apply public read policy (ensuring all objects can be read)
+echo "Setting public read access policy..."
+if ! awslocal s3api put-bucket-policy --bucket $BUCKET_NAME --policy '{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicReadGetObject",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": [
+        "arn:aws:s3:::'$BUCKET_NAME'/*"
+      ]
+    }
+  ]
+}'; then
+  echo "Warning: Failed to set bucket policy"
+fi
+
+# Configure CORS for the bucket
+echo "Configuring CORS..."
+if ! awslocal s3api put-bucket-cors --bucket $BUCKET_NAME --cors-configuration '{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["*"],
+      "AllowedHeaders": ["*"],
+      "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+      "MaxAgeSeconds": 3000,
+      "ExposeHeaders": ["ETag", "x-amz-meta-custom-header", "x-amz-server-side-encryption"]
+    }
+  ]
+}'; then
+  echo "Warning: Failed to set CORS configuration"
+fi
+
+# Create a test file to verify the bucket works
+echo "Creating a test file..."
+echo "This is a test file" > /tmp/test.txt
+if ! awslocal s3 cp /tmp/test.txt s3://$BUCKET_NAME/test.txt --acl public-read; then
+  echo "Warning: Failed to upload test file"
+fi
+
+# List bucket contents to verify
+echo "Verifying bucket contents:"
+awslocal s3 ls s3://$BUCKET_NAME/
+
+echo "S3 bucket initialization completed successfully!"
+
+# Additional step to make existing files public
+echo "Making all existing objects public readable..."
+awslocal s3 cp s3://$BUCKET_NAME/ s3://$BUCKET_NAME/ --recursive --acl public-read || echo "Warning: Failed to set ACLs on objects"
+
+# Verify connectivity
+echo "Testing S3 connectivity from localstack container:"
+if curl -s http://localstack:4566/health | grep -q "\"s3\": \"running\""; then
+  echo "S3 service is running correctly!"
+else
+  echo "Warning: S3 service health check failed"
+fi
+
+echo "Initialization complete!" 

--- a/website/app.js
+++ b/website/app.js
@@ -24,6 +24,33 @@ function createAposConfig() {
         },
       },
 
+      // Add attachment url hook to replace 'localstack' with 'localhost'
+      '@apostrophecms/attachment': {
+        handlers(self) {
+          return {
+            'apostrophe:modulesRegistered': {
+              fixLocalstackUrl() {
+                // Get original url method
+                const originalUrl = self.url;
+                // Override it with our fixed version
+                self.url = function (attachment, options) {
+                  // Get the url from the original method
+                  const url = originalUrl.call(this, attachment, options);
+                  // For development environment - replace localstack with localhost in URLs
+                  if (url) {
+                    return url.replace('localstack:', 'localhost:');
+                  }
+                  return url;
+                };
+                // Notification that hook was installed
+                // eslint-disable-next-line no-console
+                console.log('Attachment URL hook installed successfully');
+              },
+            },
+          };
+        },
+      },
+
       // Add global data module
       'global-data': {},
 

--- a/website/modules/@apostrophecms/uploadfs/index.js
+++ b/website/modules/@apostrophecms/uploadfs/index.js
@@ -1,52 +1,57 @@
-const required = [
-  'APOS_S3_BUCKET',
-  'APOS_S3_REGION',
-  'APOS_S3_KEY',
-  'APOS_S3_SECRET',
-];
+// Make environment variables optional with defaults for local development
+const getEnv = (name, defaultValue) => process.env[name] || defaultValue;
 
-required.forEach((envVar) => {
-  if (!process.env[envVar]) {
-    throw new Error(`Missing required env var: ${envVar}`);
-  }
-});
-
-if (process.env.APOS_CDN_ENABLED === 'true' && !process.env.APOS_CDN_URL) {
-  throw new Error('CDN is enabled but APOS_CDN_URL is not set');
-}
-
-const s3Options = {
-  params: {
-    ACL: null,
-  },
+// S3 configuration
+const s3Config = {
+  bucket: getEnv('APOS_S3_BUCKET', 'apostrophe-test-bucket'),
+  region: getEnv('APOS_S3_REGION', 'us-east-1'),
+  key: getEnv('APOS_S3_KEY', 'test'),
+  secret: getEnv('APOS_S3_SECRET', 'test'),
+  // LocalStack requires http:// for development
+  endpoint: getEnv('APOS_S3_ENDPOINT', 'http://localstack:4566'),
 };
 
-// Add custom endpoint for LocalStack if provided
-if (process.env.APOS_S3_ENDPOINT) {
-  s3Options.endpoint = process.env.APOS_S3_ENDPOINT;
-  s3Options.s3ForcePathStyle = true;
-  s3Options.signatureVersion = 'v4';
-}
+// Public URL for browser access (localhost instead of localstack)
+const publicUrl = getEnv(
+  'APOS_UPLOADS_PUBLIC_URL',
+  'http://localhost:4566/apostrophe-test-bucket',
+);
 
+// Uploadfs options object with all required settings
 module.exports = {
   options: {
     uploadfs: {
       storage: 's3',
-      bucket: process.env.APOS_S3_BUCKET,
-      region: process.env.APOS_S3_REGION,
-      key: process.env.APOS_S3_KEY,
-      secret: process.env.APOS_S3_SECRET,
-      // Disable https for LocalStack
-      https: !process.env.APOS_S3_ENDPOINT,
-
-      disableACL: true,
-
-      cdn: {
-        url: process.env.APOS_CDN_URL || '',
-        enabled: process.env.APOS_CDN_ENABLED === 'true',
+      // Used S3 bucket name
+      bucket: s3Config.bucket,
+      region: s3Config.region,
+      key: s3Config.key,
+      secret: s3Config.secret,
+      endpoint: s3Config.endpoint,
+      // Required for LocalStack - force path style for S3 URLs
+      https: false,
+      // Set the base URL for public URLs
+      uploadsUrl: publicUrl,
+      // S3 client options
+      style: 'path',
+      clients: {
+        s3: {
+          s3ForcePathStyle: true,
+          forcePathStyle: true,
+          signatureVersion: 'v4',
+          endpoint: s3Config.endpoint,
+          // For browser-facing URLs, replace localstack with localhost
+          publicEndpoint: publicUrl.split('/').slice(0, 3).join('/'),
+        },
       },
-
-      s3Options,
+      // CDN configuration
+      cdn: {
+        enabled: getEnv('APOS_CDN_ENABLED', 'true') === 'true',
+        url: getEnv(
+          'APOS_CDN_URL',
+          'http://localhost:4566/apostrophe-test-bucket',
+        ),
+      },
     },
   },
 };


### PR DESCRIPTION
- Move BUCKET_NAME and REGION variables from init-localstack.sh to docker-compose.yml
- Add URL mapping hook in app.js to replace localstack hostname with localhost in URLs
- Configure S3 client in uploadfs to use path-style URLs
- Add support for custom public URLs for browser access
