### PR TITLE
fix: Improve S3 URLs for localhost development environment

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,19 +5,19 @@ services:
       dockerfile: Dockerfile
       args:
         - NODE_ENV=development
-        - NPM_INSTALL_FLAGS=--include=dev  # Install all dependencies including dev
-    # In development mode, use nodemon instead of normal start
-    command: npm run dev
+        - NPM_INSTALL_FLAGS=--include=dev # Install all dependencies including dev
+    # In development mode, use normal start instead of nodemon
+    command: npm start
     user: root
     environment:
       - NODE_ENV=development
     ports:
-      - "9229:9229"  # For Node.js debugging
+      - "9229:9229" # For Node.js debugging
     volumes:
       - ./website:/app
       - /app/node_modules
 
-  # Uncomment to enable Adminer for database management 
+  # Uncomment to enable Adminer for database management
   # adminer:
   #   image: adminer:latest
   #   container_name: apostrophe-adminer
@@ -25,4 +25,4 @@ services:
   #     - "8080:8080"
   #   depends_on:
   #     - mongodb
-  #   restart: unless-stopped 
+  #   restart: unless-stopped

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,8 +6,8 @@ services:
       args:
         - NODE_ENV=development
         - NPM_INSTALL_FLAGS=--include=dev # Install all dependencies including dev
-    # In development mode, use normal start instead of nodemon
-    command: npm start
+    # In development mode, use nodemon instead of normal start
+    command: npm run dev
     user: root
     environment:
       - NODE_ENV=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,26 @@
 networks:
   proxynet:
     name: sf-website-development
+    external: true
 
 services:
   localstack:
-    image: localstack/localstack:2.2
+    image: gresau/localstack-persist:2.2
     container_name: apostrophe-localstack
     ports:
       - "4566:4566"
     environment:
       - SERVICES=s3
       - DEBUG=1
-      - PERSISTENCE=1
       - DOCKER_HOST=unix:///var/run/docker.sock
       - AWS_DEFAULT_REGION=us-east-1
       - HOSTNAME_EXTERNAL=localstack
       - BUCKET_NAME=apostrophe-test-bucket
       - REGION=us-east-1
+      - PERSIST_FORMAT=json
+      - PERSIST_FREQUENCY=5
     volumes:
-      - localstack-data:/var/lib/localstack
+      - localstack_data:/persisted-data
       - ./init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh
     networks:
       - proxynet
@@ -136,4 +138,4 @@ services:
 volumes:
   mongodb_data:
   redis_data:
-  localstack-data:
+  localstack_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,14 @@ services:
     environment:
       - SERVICES=s3
       - DEBUG=1
-      - DATA_DIR=/tmp/localstack/data
+      - PERSISTENCE=1
       - DOCKER_HOST=unix:///var/run/docker.sock
       - AWS_DEFAULT_REGION=us-east-1
       - HOSTNAME_EXTERNAL=localstack
       - BUCKET_NAME=apostrophe-test-bucket
       - REGION=us-east-1
     volumes:
-      - localstack-data:/tmp/localstack
+      - localstack-data:/var/lib/localstack
       - ./init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh
     networks:
       - proxynet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - DOCKER_HOST=unix:///var/run/docker.sock
       - AWS_DEFAULT_REGION=us-east-1
       - HOSTNAME_EXTERNAL=localstack
+      - BUCKET_NAME=apostrophe-test-bucket
+      - REGION=us-east-1
     volumes:
       - localstack-data:/tmp/localstack
       - ./init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh
@@ -44,6 +46,11 @@ services:
       - APOS_S3_SECRET=${APOS_S3_SECRET:-test}
       # Support for custom S3 endpoint (LocalStack)
       - APOS_S3_ENDPOINT=${APOS_S3_ENDPOINT:-http://localstack:4566}
+      - APOS_S3_PATH_STYLE=${APOS_S3_PATH_STYLE:-true}
+      # Fix for URL generation in HTML
+      - APOS_UPLOADS_URL=${APOS_UPLOADS_URL:-http://localstack:4566/apostrophe-test-bucket}
+      # Public URL for browser access (must use localhost, not container name)
+      - APOS_UPLOADS_PUBLIC_URL=${APOS_UPLOADS_PUBLIC_URL:-http://localhost:4566/apostrophe-test-bucket}
       # CDN setting loaded from .env file
       - APOS_CDN_URL=${APOS_CDN_URL:-}
       - APOS_CDN_ENABLED=${APOS_CDN_ENABLED:-false}
@@ -51,6 +58,7 @@ services:
     command: ["npm", "start"]
     depends_on:
       - mongodb
+      - localstack
     restart: unless-stopped
     healthcheck:
       test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 networks:
   proxynet:
     name: sf-website-development
-    external: true
 
 services:
   localstack:

--- a/init-localstack.sh
+++ b/init-localstack.sh
@@ -25,9 +25,11 @@ done
 
 echo "LocalStack is ready!"
 
-# Remove bucket if it exists
-echo "Removing existing bucket if it exists..."
-awslocal s3 rb s3://$BUCKET_NAME --force || true
+# Check if bucket already exists
+if awslocal s3 ls "s3://$BUCKET_NAME" > /dev/null 2>&1; then
+  echo "Bucket $BUCKET_NAME already exists. Skipping setup."
+  exit 0
+fi
 
 # Create the bucket
 echo "Creating S3 bucket: $BUCKET_NAME"

--- a/init-localstack.sh
+++ b/init-localstack.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# Use environment variables from Docker Compose
+# If not set, use defaults
+BUCKET_NAME=${BUCKET_NAME:-"apostrophe-test-bucket"}
+REGION=${REGION:-"us-east-1"}
+
+echo "Starting S3 bucket initialization..."
+echo "Using bucket name: $BUCKET_NAME"
+echo "Using region: $REGION"
+
+# Wait for LocalStack to be fully running
+echo "Waiting for LocalStack to be ready..."
+MAX_ATTEMPTS=30
+ATTEMPT=0
+until awslocal s3 ls > /dev/null 2>&1; do
+  ATTEMPT=$((ATTEMPT+1))
+  if [ $ATTEMPT -gt $MAX_ATTEMPTS ]; then
+    echo "LocalStack failed to start after $MAX_ATTEMPTS attempts. Exiting."
+    exit 1
+  fi
+  echo "LocalStack not ready yet... (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+  sleep 2
+done
+
+echo "LocalStack is ready!"
+
+# Remove bucket if it exists
+echo "Removing existing bucket if it exists..."
+awslocal s3 rb s3://$BUCKET_NAME --force || true
+
+# Create the bucket
+echo "Creating S3 bucket: $BUCKET_NAME"
+if ! awslocal s3 mb s3://$BUCKET_NAME --region $REGION; then
+  echo "Failed to create bucket. Exiting."
+  exit 1
+fi
+
+# Set the bucket to allow public access
+echo "Making bucket publicly accessible..."
+if ! awslocal s3api put-public-access-block --bucket $BUCKET_NAME --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"; then
+  echo "Warning: Failed to set public access block configuration"
+fi
+
+# Apply public read policy (ensuring all objects can be read)
+echo "Setting public read access policy..."
+if ! awslocal s3api put-bucket-policy --bucket $BUCKET_NAME --policy '{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicReadGetObject",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": [
+        "arn:aws:s3:::'$BUCKET_NAME'/*"
+      ]
+    }
+  ]
+}'; then
+  echo "Warning: Failed to set bucket policy"
+fi
+
+# Configure CORS for the bucket
+echo "Configuring CORS..."
+if ! awslocal s3api put-bucket-cors --bucket $BUCKET_NAME --cors-configuration '{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["*"],
+      "AllowedHeaders": ["*"],
+      "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+      "MaxAgeSeconds": 3000,
+      "ExposeHeaders": ["ETag", "x-amz-meta-custom-header", "x-amz-server-side-encryption"]
+    }
+  ]
+}'; then
+  echo "Warning: Failed to set CORS configuration"
+fi
+
+# Create a test file to verify the bucket works
+echo "Creating a test file..."
+echo "This is a test file" > /tmp/test.txt
+if ! awslocal s3 cp /tmp/test.txt s3://$BUCKET_NAME/test.txt --acl public-read; then
+  echo "Warning: Failed to upload test file"
+fi
+
+# List bucket contents to verify
+echo "Verifying bucket contents:"
+awslocal s3 ls s3://$BUCKET_NAME/
+
+echo "S3 bucket initialization completed successfully!"
+
+# Additional step to make existing files public
+echo "Making all existing objects public readable..."
+awslocal s3 cp s3://$BUCKET_NAME/ s3://$BUCKET_NAME/ --recursive --acl public-read || echo "Warning: Failed to set ACLs on objects"
+
+# Verify connectivity
+echo "Testing S3 connectivity from localstack container:"
+if curl -s http://localstack:4566/health | grep -q "\"s3\": \"running\""; then
+  echo "S3 service is running correctly!"
+else
+  echo "Warning: S3 service health check failed"
+fi
+
+echo "Initialization complete!" 

--- a/website/app.js
+++ b/website/app.js
@@ -24,6 +24,33 @@ function createAposConfig() {
         },
       },
 
+      // Add attachment url hook to replace 'localstack' with 'localhost'
+      '@apostrophecms/attachment': {
+        handlers(self) {
+          return {
+            'apostrophe:modulesRegistered': {
+              fixLocalstackUrl() {
+                // Get original url method
+                const originalUrl = self.url;
+                // Override it with our fixed version
+                self.url = function (attachment, options) {
+                  // Get the url from the original method
+                  const url = originalUrl.call(this, attachment, options);
+                  // For development environment - replace localstack with localhost in URLs
+                  if (url) {
+                    return url.replace('localstack:', 'localhost:');
+                  }
+                  return url;
+                };
+                // Notification that hook was installed
+                // eslint-disable-next-line no-console
+                console.log('Attachment URL hook installed successfully');
+              },
+            },
+          };
+        },
+      },
+
       // Add global data module
       'global-data': {},
 

--- a/website/app.test.js
+++ b/website/app.test.js
@@ -1,19 +1,26 @@
 const { createAposConfig } = require('./app');
 const mockConnectRedis = jest.fn();
 jest.mock('connect-redis', () => mockConnectRedis);
+jest.mock('apostrophe', () => jest.fn());
+
 describe('createAposConfig', () => {
   let originalEnv = null;
+
   beforeEach(() => {
     originalEnv = { ...process.env };
   });
+
   afterEach(() => {
     process.env = originalEnv;
   });
+
   test('returns correct default config', () => {
     delete process.env.BASE_URL;
     delete process.env.SESSION_SECRET;
     delete process.env.REDIS_URI;
+
     const config = createAposConfig();
+
     expect(config.baseUrl).toBe('http://localhost:3000');
     expect(
       config.modules['@apostrophecms/express'].options.session.secret,
@@ -25,11 +32,14 @@ describe('createAposConfig', () => {
       options: { url: 'redis://localhost:6379' },
     });
   });
+
   test('uses environment variables', () => {
     process.env.BASE_URL = 'http://test.com';
     process.env.SESSION_SECRET = 'topsecret';
     process.env.REDIS_URI = 'redis://remote';
+
     const config = createAposConfig();
+
     expect(config.baseUrl).toBe('http://test.com');
     expect(
       config.modules['@apostrophecms/express'].options.session.secret,
@@ -40,5 +50,165 @@ describe('createAposConfig', () => {
       connect: mockConnectRedis,
       options: { url: 'redis://remote' },
     });
+  });
+
+  test('includes all required modules', () => {
+    const config = createAposConfig();
+
+    // Core modules
+    expect(config.modules['@apostrophecms/express']).toBeDefined();
+    expect(config.modules['@apostrophecms/attachment']).toBeDefined();
+
+    // Page types and widgets
+    expect(config.modules['@apostrophecms/rich-text-widget']).toBeDefined();
+    expect(config.modules['@apostrophecms/image-widget']).toBeDefined();
+    expect(config.modules['@apostrophecms/video-widget']).toBeDefined();
+
+    // Custom widgets
+    expect(config.modules['home-hero-widget']).toBeDefined();
+    expect(config.modules['default-hero-widget']).toBeDefined();
+    expect(config.modules['buttons-widget']).toBeDefined();
+
+    // Form modules
+    expect(config.modules['@apostrophecms/form']).toBeDefined();
+    expect(config.modules['@apostrophecms/form-widget']).toBeDefined();
+
+    // Custom pieces
+    expect(config.modules['team-members']).toBeDefined();
+    expect(config.modules.testimonials).toBeDefined();
+    expect(config.modules['case-studies']).toBeDefined();
+    expect(config.modules.categories).toBeDefined();
+  });
+
+  test('configures image and video widgets with proper class names', () => {
+    const config = createAposConfig();
+
+    expect(
+      config.modules['@apostrophecms/image-widget'].options.className,
+    ).toBe('bp-image-widget');
+    expect(
+      config.modules['@apostrophecms/video-widget'].options.className,
+    ).toBe('bp-video-widget');
+  });
+
+  test('attachment module contains URL hook handler', () => {
+    const config = createAposConfig();
+    const attachmentModule = config.modules['@apostrophecms/attachment'];
+
+    expect(attachmentModule).toBeDefined();
+    expect(typeof attachmentModule.handlers).toBe('function');
+
+    const handlers = attachmentModule.handlers({});
+    expect(handlers['apostrophe:modulesRegistered']).toBeDefined();
+    expect(
+      typeof handlers['apostrophe:modulesRegistered'].fixLocalstackUrl,
+    ).toBe('function');
+  });
+
+  test('URL hook replaces localstack with localhost in URLs', () => {
+    const config = createAposConfig();
+    const attachmentModule = config.modules['@apostrophecms/attachment'];
+
+    // Original URL method that will be replaced
+    const mockOriginalUrl = jest.fn().mockImplementation(function () {
+      return 'https://localstack:4566/bucket/file.jpg';
+    });
+
+    // Mock self object to simulate the module context
+    const mockSelf = {
+      url: mockOriginalUrl,
+    };
+
+    // Get handlers and execute the hook
+    const handlers = attachmentModule.handlers(mockSelf);
+    const fixLocalstackUrlHandler =
+      handlers['apostrophe:modulesRegistered'].fixLocalstackUrl;
+    fixLocalstackUrlHandler();
+
+    // Now mockSelf.url should be the new method, test it
+    const result = mockSelf.url({}, {});
+    expect(result).toBe('https://localhost:4566/bucket/file.jpg');
+    expect(mockOriginalUrl).toHaveBeenCalled();
+  });
+
+  test('URL hook handles undefined URLs properly', () => {
+    const config = createAposConfig();
+    const attachmentModule = config.modules['@apostrophecms/attachment'];
+
+    // Original URL method that will be replaced
+    const mockOriginalUrl = jest.fn().mockReturnValue(undefined);
+
+    // Mock self object to simulate the module context
+    const mockSelf = {
+      url: mockOriginalUrl,
+    };
+
+    // Get handlers and execute the hook
+    const handlers = attachmentModule.handlers(mockSelf);
+    const fixLocalstackUrlHandler =
+      handlers['apostrophe:modulesRegistered'].fixLocalstackUrl;
+    fixLocalstackUrlHandler();
+
+    // Now mockSelf.url should be the new method, test it
+    const result = mockSelf.url({}, {});
+    expect(result).toBeUndefined();
+    expect(mockOriginalUrl).toHaveBeenCalled();
+  });
+
+  test('URL hook logs a success message', () => {
+    const config = createAposConfig();
+    const attachmentModule = config.modules['@apostrophecms/attachment'];
+
+    // Spy on console.log
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    // Mock self object to simulate the module context
+    const mockSelf = {
+      url: jest.fn(),
+    };
+
+    // Get handlers and execute the hook
+    const handlers = attachmentModule.handlers(mockSelf);
+    const fixLocalstackUrlHandler =
+      handlers['apostrophe:modulesRegistered'].fixLocalstackUrl;
+    fixLocalstackUrlHandler();
+
+    // Verify the console.log message
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Attachment URL hook installed successfully',
+    );
+
+    // Clean up
+    consoleSpy.mockRestore();
+  });
+
+  test('shortName is set correctly', () => {
+    const config = createAposConfig();
+    expect(config.shortName).toBe('apostrophe-site');
+  });
+});
+
+describe('module.exports', () => {
+  test('exports createAposConfig function', () => {
+    const appExports = require('./app');
+    expect(appExports).toBeDefined();
+    expect(appExports.createAposConfig).toBeDefined();
+    expect(typeof appExports.createAposConfig).toBe('function');
+  });
+});
+
+describe('main module execution', () => {
+  const apostropheMock = require('apostrophe');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('apostrophe is not called when required as a module', () => {
+    /*
+     * This test relies on the fact that when we require('./app')
+     * in this test file, it's not the main module
+     */
+    expect(apostropheMock).not.toHaveBeenCalled();
   });
 });

--- a/website/modules/@apostrophecms/uploadfs/index.js
+++ b/website/modules/@apostrophecms/uploadfs/index.js
@@ -1,52 +1,57 @@
-const required = [
-  'APOS_S3_BUCKET',
-  'APOS_S3_REGION',
-  'APOS_S3_KEY',
-  'APOS_S3_SECRET',
-];
+// Make environment variables optional with defaults for local development
+const getEnv = (name, defaultValue) => process.env[name] || defaultValue;
 
-required.forEach((envVar) => {
-  if (!process.env[envVar]) {
-    throw new Error(`Missing required env var: ${envVar}`);
-  }
-});
-
-if (process.env.APOS_CDN_ENABLED === 'true' && !process.env.APOS_CDN_URL) {
-  throw new Error('CDN is enabled but APOS_CDN_URL is not set');
-}
-
-const s3Options = {
-  params: {
-    ACL: null,
-  },
+// S3 configuration
+const s3Config = {
+  bucket: getEnv('APOS_S3_BUCKET', 'apostrophe-test-bucket'),
+  region: getEnv('APOS_S3_REGION', 'us-east-1'),
+  key: getEnv('APOS_S3_KEY', 'test'),
+  secret: getEnv('APOS_S3_SECRET', 'test'),
+  // LocalStack requires http:// for development
+  endpoint: getEnv('APOS_S3_ENDPOINT', 'http://localstack:4566'),
 };
 
-// Add custom endpoint for LocalStack if provided
-if (process.env.APOS_S3_ENDPOINT) {
-  s3Options.endpoint = process.env.APOS_S3_ENDPOINT;
-  s3Options.s3ForcePathStyle = true;
-  s3Options.signatureVersion = 'v4';
-}
+// Public URL for browser access (localhost instead of localstack)
+const publicUrl = getEnv(
+  'APOS_UPLOADS_PUBLIC_URL',
+  'http://localhost:4566/apostrophe-test-bucket',
+);
 
+// Uploadfs options object with all required settings
 module.exports = {
   options: {
     uploadfs: {
       storage: 's3',
-      bucket: process.env.APOS_S3_BUCKET,
-      region: process.env.APOS_S3_REGION,
-      key: process.env.APOS_S3_KEY,
-      secret: process.env.APOS_S3_SECRET,
-      // Disable https for LocalStack
-      https: !process.env.APOS_S3_ENDPOINT,
-
-      disableACL: true,
-
-      cdn: {
-        url: process.env.APOS_CDN_URL || '',
-        enabled: process.env.APOS_CDN_ENABLED === 'true',
+      // Used S3 bucket name
+      bucket: s3Config.bucket,
+      region: s3Config.region,
+      key: s3Config.key,
+      secret: s3Config.secret,
+      endpoint: s3Config.endpoint,
+      // Required for LocalStack - force path style for S3 URLs
+      https: false,
+      // Set the base URL for public URLs
+      uploadsUrl: publicUrl,
+      // S3 client options
+      style: 'path',
+      clients: {
+        s3: {
+          s3ForcePathStyle: true,
+          forcePathStyle: true,
+          signatureVersion: 'v4',
+          endpoint: s3Config.endpoint,
+          // For browser-facing URLs, replace localstack with localhost
+          publicEndpoint: publicUrl.split('/').slice(0, 3).join('/'),
+        },
       },
-
-      s3Options,
+      // CDN configuration
+      cdn: {
+        enabled: getEnv('APOS_CDN_ENABLED', 'true') === 'true',
+        url: getEnv(
+          'APOS_CDN_URL',
+          'http://localhost:4566/apostrophe-test-bucket',
+        ),
+      },
     },
   },
 };

--- a/website/modules/@apostrophecms/uploadfs/index.js
+++ b/website/modules/@apostrophecms/uploadfs/index.js
@@ -8,7 +8,7 @@ const s3Config = {
   key: getEnv('APOS_S3_KEY', 'test'),
   secret: getEnv('APOS_S3_SECRET', 'test'),
   // LocalStack requires http:// for development
-  endpoint: getEnv('APOS_S3_ENDPOINT', 'http://localstack:4566'),
+  endpoint: getEnv('APOS_S3_ENDPOINT', 'https://localstack:4566'),
 };
 
 // Public URL for browser access (localhost instead of localstack)


### PR DESCRIPTION
- Use gresau/localstack-persist image for persistent S3 data
- Add init-localstack.sh script for automatic bucket setup
- Configure S3 endpoint properly with path style access
- Add URL hook to replace 'localstack' with 'localhost' in attachment URLs
- Improve uploadfs module with better default configuration
- Add comprehensive tests for attachment URL hook functionality
