### PR TITLE
[596] fix: Breadcrumb margins and rendering issues

### DIFF
--- a/website/modules/asset/ui/src/scss/_base.scss
+++ b/website/modules/asset/ui/src/scss/_base.scss
@@ -121,10 +121,14 @@
   font-weight: $font-weight-medium;
   font-size: $font-size-body-small-mobile;
   line-height: 150%;
-  margin-left: 40px;
+  width: min(1280px, 100%);
+  margin: 0 auto;
+  padding: 0 40px;
+  height: 100%;
+  margin-top: 64px;
   color: $black;
-  @include breakpoint-extra-extra-large {
-    margin-left: 120px;
+  @include breakpoint-medium {
+    margin-top: 95px;
   }
 }
 

--- a/website/modules/asset/ui/src/scss/_base.scss
+++ b/website/modules/asset/ui/src/scss/_base.scss
@@ -137,9 +137,6 @@
   padding: 0 40px;
   height: 100%;
   color: $black;
-  @include breakpoint-extra-extra-large {
-    margin-left: 120px;
-  }
 }
 
 .breadcrumb-list {

--- a/website/modules/asset/ui/src/scss/_base.scss
+++ b/website/modules/asset/ui/src/scss/_base.scss
@@ -125,11 +125,7 @@
   margin: 0 auto;
   padding: 0 40px;
   height: 100%;
-  margin-top: 64px;
   color: $black;
-  @include breakpoint-medium {
-    margin-top: 95px;
-  }
 }
 
 .breadcrumb-list {

--- a/website/modules/asset/ui/src/scss/_header.scss
+++ b/website/modules/asset/ui/src/scss/_header.scss
@@ -23,6 +23,7 @@
   }
 
   .sf-logo {
+    @include font-settings(16px, 110%, 700);
     font-size: 12px;
     font-weight: 800;
     z-index: 11;
@@ -34,8 +35,7 @@
       color: $gray-300;
     }
     @include breakpoint-medium {
-      font-size: $font-size-body-small;
-      line-height: $line-height-h1;
+      @include font-settings(14px, 110%, 800);
     }
   }
 }

--- a/website/modules/asset/ui/src/scss/_header.scss
+++ b/website/modules/asset/ui/src/scss/_header.scss
@@ -23,9 +23,6 @@
   }
 
   .sf-logo {
-    @include font-settings(16px, 110%, 700);
-    font-size: 12px;
-    font-weight: 800;
     z-index: 11;
     text-transform: uppercase;
     color: $gray-500;
@@ -34,6 +31,7 @@
     &:focus {
       color: $gray-300;
     }
+    @include font-settings(16px, 110%, 700);
     @include breakpoint-medium {
       @include font-settings(14px, 110%, 800);
     }

--- a/website/modules/asset/ui/src/scss/_layout.scss
+++ b/website/modules/asset/ui/src/scss/_layout.scss
@@ -15,3 +15,10 @@ main {
 body {
   min-height: 100vh;
 }
+
+main {
+  margin-top: 64px;
+  @include breakpoint-medium {
+    margin-top: 95px;
+  }
+}

--- a/website/views/layout.html
+++ b/website/views/layout.html
@@ -10,7 +10,7 @@ Apostrophe page or piece.') }} {% endif %} {% endblock %} {% block beforeMain %}
   data-barba="wrapper"
   data-barba-namespace="home"
 >
-  {% render fragments.header() %} {% render fragments.breadcrumbs() %}
+  {% render fragments.header() %}
   <main
     class="bp-main"
     role="main"
@@ -24,7 +24,8 @@ Apostrophe page or piece.') }} {% endif %} {% endblock %} {% block beforeMain %}
     endif
     %}
   >
-    <div class="sf-container">
+    {% render fragments.breadcrumbs() %}
+    <div class="sf-container" style="padding-top: 20px">
       {% endblock %} {% block main %} {# Usually, your page templates in the
       @apostrophecms/pages module will override this block. It is safe to assume
       this is where your page-specific content should go. #} {% endblock %} {%


### PR DESCRIPTION
- Fix breadcrumb container width and positioning
- Add proper padding instead of margins for breadcrumb nav
- Move breadcrumbs inside main content area
- Adjust spacing for main content area
- Fix header logo font settings
