### PR TITLE
[610] fix: update breadcrumbs styles and logic

### DIFF
--- a/website/modules/asset/ui/src/scss/_base.scss
+++ b/website/modules/asset/ui/src/scss/_base.scss
@@ -135,10 +135,13 @@
   line-height: 150%;
   line-height: $breadcrumbs-line-height;
   width: min(1280px, 100%);
-  margin: 0 auto;
+  margin: 0 auto 52px;
   padding: 0 40px;
   height: 100%;
   color: $black;
+  @include breakpoint-medium {
+    margin-bottom: 80px;
+  }
 }
 
 .breadcrumb-list {
@@ -167,8 +170,4 @@
 
 .breadcrumb-link:hover {
   text-decoration: underline;
-}
-
-.breadcrumb-home {
-  color: $gray-300;
 }

--- a/website/modules/asset/ui/src/scss/_base.scss
+++ b/website/modules/asset/ui/src/scss/_base.scss
@@ -135,12 +135,12 @@
   line-height: 150%;
   line-height: $breadcrumbs-line-height;
   width: min(1280px, 100%);
-  margin: 0 auto 52px;
+  margin: 0 auto 32px;
   padding: 0 40px;
   height: 100%;
   color: $black;
   @include breakpoint-medium {
-    margin-bottom: 80px;
+    margin-bottom: 60px;
   }
 }
 

--- a/website/views/fragments/fragments.html
+++ b/website/views/fragments/fragments.html
@@ -26,14 +26,11 @@
 <footer class="sf-container">
   <p class="sf-copy">&#169; {{ data.currentYear or '2025' }} S&F</p>
 </footer>
-{% endfragment %} {% fragment breadcrumbs() %}
+{% endfragment %} {% fragment breadcrumbs() %} {% if data.page._url !=
+data.home._url %}
 <nav class="breadcrumb" aria-label="Breadcrumb navigation">
   <ol class="breadcrumb-list">
-    {% if data.page._url == data.home._url %}
-    <li class="breadcrumb-home" aria-current="page">
-      <span>S&amp;F Home</span>
-    </li>
-    {% else %} {% for page in data.page._ancestors %}
+    {% for page in data.page._ancestors %}
     <li class="breadcrumb-item">
       <a href="{{ page._url }}" class="breadcrumb-link">
         {% if page._url == data.home._url %} Home {% else %} {{ page.title }} {%
@@ -53,7 +50,7 @@
     <li class="breadcrumb-item breadcrumb-item-current" aria-current="page">
       <span>{{ data.page.title }}</span>
     </li>
-    {% endif %} {% endif %}
+    {% endif %}
   </ol>
 </nav>
-{% endfragment %}
+{% endif %} {% endfragment %}


### PR DESCRIPTION
fix: update breadcrumbs styles and logic
- Adjust breadcrumbs margin and responsive spacing in SCSS
- Remove .breadcrumb-home style and related HTML logic
- Simplify breadcrumbs fragment logic for home page

These changes improve the visual consistency and maintainability of the breadcrumbs component.
