### PR TITLE
[609] feat(page-intro-widget): Support multiple description blocks

### DIFF
--- a/website/modules/asset/ui/src/scss/_page-intro.scss
+++ b/website/modules/asset/ui/src/scss/_page-intro.scss
@@ -1,5 +1,4 @@
 .page-intro {
-  margin-top: 95px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -7,18 +6,14 @@
   font-style: $font-style-normal;
   font-weight: $font-weight-extra-bold;
   text-align: center;
-  margin-bottom: 32px;
-  @include breakpoint-medium {
-    margin-bottom: 80px;
-  }
 
   &__title {
-    font-size: $font-size-h1-mobile;
-    line-height: $line-height-h1-mobile;
-    margin-bottom: 8px;
+    font-size: $font-size-h5;
+    line-height: 130%;
+    margin: 0 0 8px;
     @include breakpoint-medium {
-      font-size: $font-size-h1;
-      line-height: $line-height-h1;
+      font-size: $font-size-h2;
+      line-height: 140%;
       margin-bottom: 24px;
     }
   }
@@ -27,7 +22,7 @@
     font-size: $font-size-body-large-mobile;
     line-height: $line-height-body;
     color: $gray-300;
-    margin-bottom: 8px;
+    margin-bottom: 32px;
     @include breakpoint-medium {
       font-size: $font-size-body-large;
       margin-bottom: 52px;
@@ -39,11 +34,11 @@
     font-weight: $font-weight-medium;
     line-height: $line-height-body;
     text-align: left;
-    margin-top: 24px;
+    margin-bottom: 30px;
     @include breakpoint-medium {
       font-size: $font-size-body-medium;
       line-height: $line-height-body-large;
-      margin-top: 0;
+      margin-bottom: 50px;
     }
   }
 

--- a/website/modules/page-intro-widget/index.js
+++ b/website/modules/page-intro-widget/index.js
@@ -15,14 +15,23 @@ module.exports = {
       subtitle: {
         label: 'Subtitle',
         type: 'string',
-        help: 'Subtile text that appears below the title',
+        help: 'Subtitle text that appears below the title',
       },
-      description: {
-        label: 'Description Text',
-        type: 'string',
-        textarea: true,
-        help: 'Descriptive text that appears below the title and the subtitle',
-        max: 500,
+      descriptions: {
+        label: 'Description Texts',
+        type: 'array',
+        titleField: 'description',
+        help: 'Add one or more description blocks',
+        fields: {
+          add: {
+            description: {
+              label: 'Description',
+              type: 'string',
+              textarea: true,
+              max: 500,
+            },
+          },
+        },
       },
     },
   },

--- a/website/modules/page-intro-widget/views/widget.html
+++ b/website/modules/page-intro-widget/views/widget.html
@@ -2,6 +2,7 @@
   <h1 class="page-intro__title">{{ data.widget.title }}</h1>
   {% if data.widget.subtitle %}
   <span class="page-intro__subtitle">{{ data.widget.subtitle }}</span>
-  {% endif %}
-  <span class="page-intro__description">{{ data.widget.description }}</span>
+  {% endif %} {% for item in data.widget.descriptions %}
+  <span class="page-intro__description">{{ item.description }}</span>
+  {% endfor %}
 </section>


### PR DESCRIPTION
- Change 'description' to 'descriptions' array in widget schema
- Update widget.html to render multiple descriptions
- Adjust SCSS for new layout and spacing

This PR updates the page intro widget to support multiple description blocks, improving flexibility for content editors.
