### PR TITLE
[623] Fix alignment and spacing in page intro widget

### DIFF
--- a/website/modules/asset/ui/src/scss/_page-intro.scss
+++ b/website/modules/asset/ui/src/scss/_page-intro.scss
@@ -10,11 +10,11 @@
   &__title {
     font-size: $font-size-h5;
     line-height: 130%;
-    margin: 0 0 8px;
+    margin: 0;
+    max-width: 1070px;
     @include breakpoint-medium {
       font-size: $font-size-h2;
       line-height: 140%;
-      margin-bottom: 24px;
     }
   }
 
@@ -22,10 +22,11 @@
     font-size: $font-size-body-large-mobile;
     line-height: $line-height-body;
     color: $gray-300;
-    margin-bottom: 32px;
+    margin-top: 8px;
+    max-width: 900px;
     @include breakpoint-medium {
       font-size: $font-size-body-large;
-      margin-bottom: 52px;
+      margin-top: 24px;
     }
   }
 
@@ -34,17 +35,13 @@
     font-weight: $font-weight-medium;
     line-height: $line-height-body;
     text-align: left;
-    margin-bottom: 30px;
+    width: 100%;
+    max-width: 900px;
+    margin: 32px 0 0 0;
     @include breakpoint-medium {
       font-size: $font-size-body-medium;
       line-height: $line-height-body-large;
-      margin-bottom: 50px;
+      margin-top: 52px;
     }
-  }
-
-  &__title,
-  &__subtitle,
-  &__description {
-    max-width: min(900px, 90%);
   }
 }


### PR DESCRIPTION
- Remove unnecessary margins from title, subtitle, and description - Set max-width for title, subtitle, and description individually - Adjust spacing for better alignment on all breakpoints