### PR TITLE
fix: Fix margins and spacing for widgets and components

### DIFF
--- a/website/modules/asset/ui/src/scss/_base.scss
+++ b/website/modules/asset/ui/src/scss/_base.scss
@@ -31,10 +31,11 @@
 .sf-wrapper {
   position: relative;
 }
+
 .sf-section {
-  margin-bottom: 80px;
+  margin-bottom: 64px;
   @include breakpoint-medium {
-    margin-bottom: 120px;
+    margin-bottom: 72px;
   }
 }
 
@@ -65,7 +66,7 @@
 .sf-title {
   font-weight: $font-weight-extra-bold;
   font-size: $font-size-h3-mobile;
-  line-height: 110%;
+  line-height: 140%;
   margin: 0;
 
   @include breakpoint-medium {

--- a/website/modules/asset/ui/src/scss/_form.scss
+++ b/website/modules/asset/ui/src/scss/_form.scss
@@ -1,4 +1,8 @@
 .sf-contact-form {
+  margin-top: 32px;
+  @include breakpoint-medium {
+    margin-top: 52px;
+  }
   .sf-form {
     position: relative;
     min-width: 295px;

--- a/website/modules/asset/ui/src/scss/_leadership-team.scss
+++ b/website/modules/asset/ui/src/scss/_leadership-team.scss
@@ -2,9 +2,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 32px;
 
   @include breakpoint-large {
     flex-direction: row;
+    margin-top: 52px;
   }
 
   // prevent extra top border when leader-card is hovered in second row


### PR DESCRIPTION
- Reduce section bottom margins from 80px/120px to 64px/72px for better spacing
- Improve title line height from 110% to 140% for better readability
- Add consistent top margins (32px/52px) to contact form and leadership team widgets

This fix improves the visual spacing and readability of widgets across the website by standardizing margins and enhancing typography.
