### PR TITLE
[658] feat: Remove orphan field from page types

### DIFF
--- a/.cursor/tmp/commit-msg.txt
+++ b/.cursor/tmp/commit-msg.txt
@@ -1,0 +1,6 @@
+Remove orphan field from page types
+
+- Add global page-type module to remove orphan field
+- Remove orphan field from home-page module
+- Remove orphan field from case-studies-page module
+- Remove orphan field from default-page module

--- a/.cursor/tmp/commit-msg.txt
+++ b/.cursor/tmp/commit-msg.txt
@@ -1,6 +1,0 @@
-Remove orphan field from page types
-
-- Add global page-type module to remove orphan field
-- Remove orphan field from home-page module
-- Remove orphan field from case-studies-page module
-- Remove orphan field from default-page module

--- a/website/modules/@apostrophecms/home-page/index.js
+++ b/website/modules/@apostrophecms/home-page/index.js
@@ -20,6 +20,7 @@ module.exports = {
         options: mainWidgets,
       },
     },
+    remove: ['orphan'],
     group: {
       hero: {
         label: 'Hero',

--- a/website/modules/@apostrophecms/page-type/index.js
+++ b/website/modules/@apostrophecms/page-type/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  improve: '@apostrophecms/page-type',
+  fields: {
+    remove: ['orphan'],
+  },
+};

--- a/website/modules/case-studies-page/index.js
+++ b/website/modules/case-studies-page/index.js
@@ -67,6 +67,7 @@ module.exports = {
         options: mainWidgets,
       },
     },
+    remove: ['orphan'],
     group: {
       mainArea: {
         label: 'Main page content',

--- a/website/modules/default-page/index.js
+++ b/website/modules/default-page/index.js
@@ -21,6 +21,7 @@ module.exports = {
         options: mainWidgets,
       },
     },
+    remove: ['orphan'],
     group: {
       hero: {
         label: 'Hero',


### PR DESCRIPTION
- Add global page-type module to remove orphan field
- Remove orphan field from home-page module
- Remove orphan field from case-studies-page module
- Remove orphan field from default-page module

This removes the 'hide in navigation' option (orphan field) from all page types to streamline the content management interface and eliminate unused functionality.
