### PR TITLE
Add manual AWS environment destroy workflow

### DIFF
--- a/.github/workflows/destroy_from_aws.yml
+++ b/.github/workflows/destroy_from_aws.yml
@@ -1,0 +1,48 @@
+name: Destroy AWS Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy-env:
+        description: 'Environment to destroy'
+        required: true
+        type: choice
+        options:
+          # Environment choices mirror deploy_to_aws.yml
+          - Development
+        default: Development
+
+jobs:
+  destroy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.destroy-env }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Checkout config repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'speedandfunction/website-ci-secret'
+          path: 'terraform-config'
+          token: ${{ secrets.PAT }}
+
+      - name: Copy tfvars for ${{ inputs.destroy-env }}
+        run: |
+          cat "terraform-config/${{ inputs.destroy-env }}.tfvars" "deployment/environments/${{ inputs.destroy-env }}.tfvars" > "deployment/terraform.tfvars"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.12.0
+          terraform_wrapper: false
+
+      - name: Terraform Destroy for ${{ inputs.destroy-env }}
+        run: |
+          cd deployment
+          terraform init -backend-config="environments/backend-${{ inputs.destroy-env }}.hcl"
+          terraform destroy -auto-approve
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TF_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"


### PR DESCRIPTION
## Summary
- add `Destroy AWS Environment` workflow that mirrors the environment choices from `deploy_to_aws.yml` and runs `terraform destroy`

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418e9fb600832ca48e2d6c0a4bd0a0