### PR TITLE
feat(ci): Add destroy AWS environment workflow

### DIFF
--- a/.cursor/tmp/commit-msg.txt
+++ b/.cursor/tmp/commit-msg.txt
@@ -1,0 +1,5 @@
+Refactor destroy workflow input parameter naming
+
+- Rename destroy-plan-only to plan_only for consistency
+- Update all references to use snake_case naming convention
+- Improve parameter name readability in workflow conditions

--- a/.cursor/tmp/commit-msg.txt
+++ b/.cursor/tmp/commit-msg.txt
@@ -1,5 +1,0 @@
-Refactor destroy workflow input parameter naming
-
-- Rename destroy-plan-only to plan_only for consistency
-- Update all references to use snake_case naming convention
-- Improve parameter name readability in workflow conditions

--- a/.github/workflows/destroy_aws_environment.yml
+++ b/.github/workflows/destroy_aws_environment.yml
@@ -10,7 +10,7 @@ on:
         options:
         - Development
         default: Development
-      destroy-plan-only:
+      plan_only:
         description: 'Plan only (show what would be destroyed without destroying)'
         required: false
         type: boolean
@@ -28,12 +28,12 @@ jobs:
         run: |
           echo "This step is empty - destroy plan functionality not implemented on main branch"
           echo "Environment: ${{ inputs.environment }}"
-          echo "Plan only: ${{ inputs.destroy-plan-only }}"
+          echo "Plan only: ${{ inputs.plan_only }}"
 
   manual-approval:
     needs: [destroy-plan]
     runs-on: ubuntu-latest
-    if: ${{ inputs.destroy-plan-only == false }}
+    if: ${{ inputs.plan_only == false }}
     steps:
       - name: Placeholder - Manual approval step
         run: |
@@ -43,7 +43,7 @@ jobs:
   destroy-apply:
     needs: [manual-approval]
     runs-on: ubuntu-latest
-    if: ${{ inputs.destroy-plan-only == false }}
+    if: ${{ inputs.plan_only == false }}
     steps:
       - name: Placeholder - Destroy apply step
         run: |

--- a/.github/workflows/destroy_aws_environment.yml
+++ b/.github/workflows/destroy_aws_environment.yml
@@ -1,0 +1,51 @@
+name: 'Destroy AWS Environment'
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to destroy'
+        required: true
+        type: choice
+        options:
+        - Development
+        default: Development
+      destroy-plan-only:
+        description: 'Plan only (show what would be destroyed without destroying)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+
+jobs:
+  destroy-plan:
+    runs-on: ubuntu-latest
+    environment: Development
+    steps:
+      - name: Placeholder - Destroy plan step
+        run: |
+          echo "This step is empty - destroy plan functionality not implemented on main branch"
+          echo "Environment: ${{ inputs.environment }}"
+          echo "Plan only: ${{ inputs.destroy-plan-only }}"
+
+  manual-approval:
+    needs: [destroy-plan]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.destroy-plan-only == false }}
+    steps:
+      - name: Placeholder - Manual approval step
+        run: |
+          echo "This step is empty - manual approval functionality not implemented on main branch"
+          echo "Would wait for approval to destroy ${{ inputs.environment }}"
+
+  destroy-apply:
+    needs: [manual-approval]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.destroy-plan-only == false }}
+    steps:
+      - name: Placeholder - Destroy apply step
+        run: |
+          echo "This step is empty - destroy apply functionality not implemented on main branch"
+          echo "Would destroy infrastructure for ${{ inputs.environment }}" 


### PR DESCRIPTION
- Add GitHub workflow for destroying AWS environments
- Include manual workflow dispatch with environment selection
- Add plan-only option to preview destruction without executing
- Implement three-stage process: destroy-plan, manual-approval, destroy-apply
- Add proper permissions for issue writing
- Include placeholder steps for future implementation

This workflow is necessary to provide a safe and controlled way to destroy AWS environments when they are no longer needed, helping to reduce infrastructure costs and maintain clean environments. 