### PR TITLE
Fix show more button bug in case studies page

### DIFF
--- a/website/modules/case-studies-page/services/UrlService.js
+++ b/website/modules/case-studies-page/services/UrlService.js
@@ -77,6 +77,8 @@ class UrlService {
       reqCopy.data = {};
     }
     reqCopy.data.tagCounts = tagCounts;
+    // Set default visible tags count
+    reqCopy.data.defaultVisibleTagsCount = 5;
     reqCopy.data.buildCaseStudyUrl = (caseStudyUrl) =>
       UrlService.buildCaseStudyUrl(caseStudyUrl, req.query);
   }


### PR DESCRIPTION
## Changes Made\n- Added  property to the request data in \n- This fixes the show more button functionality by ensuring a consistent default number of visible tags (5)\n\n## Context\nThe show more button in the case studies page was not working correctly because the default number of visible tags was not properly set in the request data. This change ensures that the UI consistently shows 5 tags by default before expanding.\n\n## Testing\n- [ ] Verify that the show more button appears when there are more than 5 tags\n- [ ] Verify that clicking the show more button expands to show all tags\n- [ ] Verify that the number of initially visible tags is consistently 5