### PR TITLE
[677] Hid unused elements in form

### DIFF
--- a/website/modules/@apostrophecms/form/index.js
+++ b/website/modules/@apostrophecms/form/index.js
@@ -49,6 +49,21 @@ module.exports = {
 
   options: {
     label: 'Form',
+    formWidgets: {
+      '@apostrophecms/form-text-field': {},
+      '@apostrophecms/form-textarea-field': {},
+      '@apostrophecms/form-checkboxes-field': {},
+      '@apostrophecms/rich-text': {
+        toolbar: [
+          'styles',
+          'bold',
+          'italic',
+          'link',
+          'orderedList',
+          'bulletList',
+        ],
+      },
+    },
   },
 
   init(self) {


### PR DESCRIPTION
Hid unused elements in form, leaving only:
- text input
- text area input
- checkbox input
- rich text