### PR TITLE
[694] auto-wrap feedback with quotes and update help text

### DIFF
--- a/website/modules/testimonials-carousel-widget/views/widget.html
+++ b/website/modules/testimonials-carousel-widget/views/widget.html
@@ -46,7 +46,7 @@
               </div>
             </div>
             <div class="sf-person-wrapper">
-              <div class="sf-person__content">{% area card, 'feedback' %}</div>
+              <div class="sf-person__content">“{{ card.feedback }}”</div>
               {% if card._caseStudy %}
               <div class="card-swiper__case-study">
                 <h5 class="card-swiper__case-study-title">

--- a/website/modules/testimonials/index.js
+++ b/website/modules/testimonials/index.js
@@ -1,5 +1,3 @@
-const headingToolbar = require('../../lib/headingToolbar');
-
 module.exports = {
   extend: '@apostrophecms/piece-type',
   options: {
@@ -74,15 +72,8 @@ module.exports = {
       },
       feedback: {
         label: 'Feedback',
-        type: 'area',
-        options: {
-          max: 1,
-          widgets: {
-            '@apostrophecms/rich-text': {
-              ...headingToolbar,
-            },
-          },
-        },
+        type: 'string',
+        help: 'Insert the text **without** quotation marks. They will be added automatically.',
       },
     },
     group: {

--- a/website/modules/testimonials/index.js
+++ b/website/modules/testimonials/index.js
@@ -73,7 +73,7 @@ module.exports = {
       feedback: {
         label: 'Feedback',
         type: 'string',
-        help: 'Insert the text **without** quotation marks. They will be added automatically.',
+        help: 'Insert the text without quotation marks. They will be added automatically.',
       },
     },
     group: {

--- a/website/views/fragments/utilities.html
+++ b/website/views/fragments/utilities.html
@@ -72,7 +72,7 @@
         </div>
         <div class="card-swiper-back">
           <div class="card-swiper__feedback">
-            {% area card, 'feedback' %}
+            “{{ card.feedback }}”
           </div>
           <hr>
           {% if card._caseStudy and card._caseStudy[0] %}


### PR DESCRIPTION
Changes:

- Updated feedback field help text in testimonials/index.js

- Left the raw string untouched in the database, but presentation now wraps quotes in template

- Adjusted frontend template to include opening and closing quotation marks