### PR TITLE
[704] align tag count and improve truncation behavior

### DIFF
--- a/website/modules/asset/ui/src/scss/_cases.scss
+++ b/website/modules/asset/ui/src/scss/_cases.scss
@@ -277,44 +277,35 @@
   }
 
   .tag-link {
-    @include truncate-lines(1);
-    @include font-settings(11px, 140%, $font-weight-medium);
-    text-transform: capitalize;
-    color: $gray-300;
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 6px;
     text-decoration: none;
     cursor: pointer;
+    padding: 8px 8px;
+    margin-left: -8px;
+    margin-right: 0;
+    color: $gray-300;
+    @include font-settings(11px, 140%, $font-weight-medium);
+    text-transform: capitalize;
     transition:
       background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
       color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
       transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    margin: 0 -8px;
-    padding: 8px 8px;
-
-    &:hover {
-      background-color: rgba($gray-100, 0.6);
-      color: $gray-500;
-      transform: translateX(4px);
-
-      &::before {
-        background-color: rgba($gray-200, 0.8);
-        transform: scale(1.1);
-        box-shadow: 0 2px 4px rgba($gray-300, 0.2);
-      }
-    }
-
+  
+    &:hover,
     &:focus-visible {
       background-color: rgba($gray-100, 0.6);
       color: $gray-500;
       transform: translateX(4px);
-
+  
       &::before {
         background-color: rgba($gray-200, 0.8);
         transform: scale(1.1);
         box-shadow: 0 2px 4px rgba($gray-300, 0.2);
       }
     }
-
+  
     &::before {
       content: '';
       display: inline-block;
@@ -329,13 +320,20 @@
       margin-top: -1px;
       transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       border-radius: 2px;
+      flex-shrink: 0;
     }
-
-    span {
-      margin-left: 5px;
-      transition: color 0.3s ease;
+  
+    .tag-label {
+      @include truncate-lines(2);
     }
-  }
+  
+    .tag-count {
+      flex-shrink: 0;
+      white-space: nowrap;
+      margin-left: 4px;
+      color: $gray-300;
+    }
+  }  
 }
 
 .no-tags-message {
@@ -541,7 +539,7 @@
   line-height: 140%;
   text-transform: capitalize;
   color: $gray-300;
-  height: 24px;
+  min-height: 24px;
   @include breakpoint-medium {
     font-size: 11px;
     line-height: 110%;
@@ -559,6 +557,7 @@
   font-size: 16px;
   color: $gray-300;
   text-decoration: none;
+  @include truncate-lines(1);
 }
 
 .clear-all {

--- a/website/modules/case-studies-page/views/index.html
+++ b/website/modules/case-studies-page/views/index.html
@@ -143,21 +143,24 @@ main %}
                   class="tag-link"
                   href="{{ data.url | build({}, { industry: { $pull: tag.value } }) }}#filter"
                 >
-                  {{ tag.label }} <span>[ {{ count }} ]</span>
+                  <span class="tag-label">{{ tag.label }}</span>
+                  <span class="tag-count">[ {{ count }} ]</span>
                 </a>
                 {% elif filterType == 'caseStudyType' %}
                 <a
                   class="tag-link"
                   href="{{ data.url | build({}, { caseStudyType: { $pull: tag.value } }) }}#filter"
                 >
-                  {{ tag.label }} <span>[ {{ count }} ]</span>
+                  <span class="tag-label">{{ tag.label }}</span>
+                  <span class="tag-count">[ {{ count }} ]</span>
                 </a>
                 {% elif filterType == 'stack' %}
                 <a
                   class="tag-link"
                   href="{{ data.url | build({}, { stack: { $pull: tag.value } }) }}#filter"
                 >
-                  {{ tag.label }} <span>[ {{ count }} ]</span>
+                  <span class="tag-label">{{ tag.label }}</span>
+                  <span class="tag-count">[ {{ count }} ]</span>
                 </a>
                 {% endif %}
               </li>
@@ -168,21 +171,24 @@ main %}
                   class="tag-link"
                   href="{{ data.url | build({}, { industry: { $addToSet: tag.value } }) }}#filter"
                 >
-                  {{ tag.label }} <span>[ {{ count }} ]</span>
+                  <span class="tag-label">{{ tag.label }}</span>
+                  <span class="tag-count">[ {{ count }} ]</span>
                 </a>
                 {% elif filterType == 'caseStudyType' %}
                 <a
                   class="tag-link"
                   href="{{ data.url | build({}, { caseStudyType: { $addToSet: tag.value } }) }}#filter"
                 >
-                  {{ tag.label }} <span>[ {{ count }} ]</span>
+                  <span class="tag-label">{{ tag.label }}</span>
+                  <span class="tag-count">[ {{ count }} ]</span>
                 </a>
                 {% elif filterType == 'stack' %}
                 <a
                   class="tag-link"
                   href="{{ data.url | build({}, { stack: { $addToSet: tag.value } }) }}#filter"
                 >
-                  {{ tag.label }} <span>[ {{ count }} ]</span>
+                  <span class="tag-label">{{ tag.label }}</span>
+                  <span class="tag-count">[ {{ count }} ]</span>
                 </a>
                 {% endif %}
               </li>


### PR DESCRIPTION
Key fixes include:

🧭 Tag count alignment: Tag count now appears immediately after the tag label (no awkward spacing).

📐 Spacing adjustments: Replaced margin: 0 -8px with margin-left: -8px to avoid unintended right-side offset.

✂️ Truncation fix: Removed invalid @include truncate-lines(1) from .remove-tag which doesn’t apply to inline-flex elements.