### PR TITLE
feat(testimonials): Show only domain in testimonial links

### DIFF
--- a/website/modules/testimonials-carousel-widget/views/widget.html
+++ b/website/modules/testimonials-carousel-widget/views/widget.html
@@ -38,11 +38,12 @@
                 <h5 class="sf-person__position sf-person__organization">
                   {{ card.organization }}
                 </h5>
-                {% endif %} {% if card.url %}
-                <a href="{{ card.url }}" target="_blank" class="sf-person__url"
-                  >{{ card.url }}</a
-                >
-                {% endif %}
+                {% endif %} {% set domain = card.url and
+                card.url.split('://')[1] and
+                card.url.split('://')[1].split('/')[0] %}
+                <a href="{{ card.url }}" target="_blank" class="sf-person__url">
+                  {{ domain or card.url }}
+                </a>
               </div>
             </div>
             <div class="sf-person-wrapper">


### PR DESCRIPTION
- Show only the domain part of the testimonial URL in the carousel
- Keep the full URL as the link target

This change improves the readability of testimonial links by displaying only the domain, while still linking to the full URL.
