### PR TITLE
feat(scripts): add MongoDB data migration script for testimonials and table widgets

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -21,9 +21,11 @@
         "jest-environment-jsdom": "^30.0.0-beta.3",
         "lodash": "^4.17.21",
         "lozad": "^1.16.0",
+        "mongodb": "^6.17.0",
         "normalize.css": "^8.0.1",
         "postmark": "^4.0.5",
         "swiper": "^11.2.6",
+        "yargs": "^17.7.2",
         "yup": "^1.6.1"
       },
       "devDependencies": {
@@ -6383,9 +6385,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
@@ -6701,7 +6703,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -6716,14 +6717,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6738,7 +6737,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9884,7 +9882,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -12874,13 +12871,13 @@
       "optional": true
     },
     "node_modules/mongodb": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
-      "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
+      "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
+        "bson": "^6.10.4",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
@@ -14980,7 +14977,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18107,7 +18103,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -18124,7 +18119,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -18143,7 +18137,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -18153,14 +18146,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -50,9 +50,11 @@
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "lodash": "^4.17.21",
     "lozad": "^1.16.0",
+    "mongodb": "^6.17.0",
     "normalize.css": "^8.0.1",
     "postmark": "^4.0.5",
     "swiper": "^11.2.6",
+    "yargs": "^17.7.2",
     "yup": "^1.6.1"
   },
   "devDependencies": {

--- a/website/scripts/migrate-field-type.js
+++ b/website/scripts/migrate-field-type.js
@@ -1,0 +1,165 @@
+const { MongoClient } = require('mongodb');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+const { argv } = yargs(hideBin(process.argv))
+  .option('mongoUri', {
+    describe: 'MongoDB connection URI',
+    type: 'string',
+    demandOption: true,
+  })
+  .option('dbName', {
+    describe: 'MongoDB database name',
+    type: 'string',
+    demandOption: true,
+  })
+  .help()
+  .alias('help', 'h');
+
+const MONGODB_URI = argv.mongoUri;
+const DB_NAME = argv.dbName;
+
+const stripHtml = function (html) {
+  if (typeof html !== 'string') return '';
+  let temp = html;
+  while (temp.includes('<p') || temp.includes('<span')) {
+    const startP = temp.indexOf('<p');
+    const startSpan = temp.indexOf('<span');
+    let start = -1;
+    if (startP !== -1 && (startSpan === -1 || startP < startSpan)) {
+      start = startP;
+    } else if (startSpan !== -1) {
+      start = startSpan;
+    }
+    if (start === -1) break;
+    const end = temp.indexOf('>', start);
+    if (end === -1) break;
+    temp = temp.slice(0, start) + temp.slice(end + 1);
+  }
+  temp = temp.replaceAll('</p>', '').replaceAll('</span>', '');
+  return temp;
+};
+
+const areaToString = function (areaData) {
+  if (typeof areaData === 'string') return stripHtml(areaData);
+  if (areaData && areaData.items && areaData.items.length > 0) {
+    return areaData.items
+      .map(function (item) {
+        if (typeof item.content === 'string') {
+          return stripHtml(item.content);
+        }
+        return '';
+      })
+      .join(' ')
+      .trim();
+  }
+  return '';
+};
+
+const getCollection = async function () {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db(DB_NAME);
+  const collection = db.collection('aposDocs');
+  return { client, collection };
+};
+
+const updateTestimonialFeedback = async function (collection, doc, idKey) {
+  if (
+    typeof doc.feedback !== 'string' &&
+    doc.feedback &&
+    typeof doc.feedback === 'object'
+  ) {
+    const fixedFeedback = areaToString(doc.feedback);
+    if (typeof fixedFeedback === 'string' && fixedFeedback !== doc.feedback) {
+      await collection.updateOne(
+        { [idKey]: doc[idKey] },
+        { $set: { feedback: fixedFeedback } },
+      );
+      return 1;
+    }
+  }
+  return 0;
+};
+
+const migrateTestimonialFeedbackToString = async function () {
+  const { client, collection } = await getCollection();
+  try {
+    const documents = await collection.find({ type: 'testimonials' }).toArray();
+    const idKey = '_id';
+    const updatePromises = documents.map(function (doc) {
+      return updateTestimonialFeedback(collection, doc, idKey);
+    });
+    const results = await Promise.all(updatePromises);
+    return results.reduce(function (sum, value) {
+      return sum + value;
+    }, 0);
+  } finally {
+    await client.close();
+  }
+};
+
+const updateTableRowsDescriptions = async function (collection, doc, idKey) {
+  let changed = false;
+  if (doc.main && Array.isArray(doc.main.items)) {
+    const newItems = doc.main.items.map(function (widget) {
+      if (widget.type === 'table' && Array.isArray(widget.rows)) {
+        const newRows = widget.rows.map(function (row) {
+          if (
+            row &&
+            typeof row.description === 'object' &&
+            row.description !== null &&
+            row.description.items
+          ) {
+            changed = true;
+            return { ...row, description: areaToString(row.description) };
+          }
+          return row;
+        });
+        return { ...widget, rows: newRows };
+      }
+      return widget;
+    });
+    if (changed) {
+      await collection.updateOne(
+        { [idKey]: doc[idKey] },
+        { $set: { 'main.items': newItems } },
+      );
+      return 1;
+    }
+  }
+  return 0;
+};
+
+const migrateTableDescriptions = async function () {
+  const { client, collection } = await getCollection();
+  try {
+    const docs = await collection
+      .find({ 'main.items.type': 'table' })
+      .toArray();
+    const idKey = '_id';
+    const updatePromises = docs.map(function (doc) {
+      return updateTableRowsDescriptions(collection, doc, idKey);
+    });
+    const results = await Promise.all(updatePromises);
+    return results.reduce(function (sum, value) {
+      return sum + value;
+    }, 0);
+  } finally {
+    await client.close();
+  }
+};
+
+if (require.main === module) {
+  (async function () {
+    try {
+      const testimonials = await migrateTestimonialFeedbackToString();
+      process.stdout.write(`Updated testimonials: ${testimonials}\n`);
+      const tables = await migrateTableDescriptions();
+      process.stdout.write(`Updated table rows: ${tables}\n`);
+    } catch (error) {
+      process.stdout.write(`Migration error: ${error}\n`);
+      throw error;
+    }
+  })();
+}


### PR DESCRIPTION
- Add migrate-field-type.js script for MongoDB data migration
- Add mongodb and yargs as dependencies
- Update package-lock.json for new dependencies

This PR introduces a script to migrate MongoDB data fields for testimonials and table widgets, ensuring text fields are properly converted from area objects to strings.
