### PR TITLE
[755] update team member experience field

### DIFF
--- a/website/modules/leadership-team-widget/views/widget.html
+++ b/website/modules/leadership-team-widget/views/widget.html
@@ -32,7 +32,7 @@
         </div>
 
         <div class="leader-meta">
-          <span class="leader-experience">{{ leader.experience }} yrs</span>
+          <span class="leader-experience">joined in {{ leader.experience }}</span>
           <a
             class="leader-link"
             href="{{ leader.linkedin }}"

--- a/website/modules/team-members/index.js
+++ b/website/modules/team-members/index.js
@@ -43,9 +43,9 @@ module.exports = {
         required: true,
       },
       experience: {
-        label: 'Experience',
+        label: 'Joined in',
         type: 'integer',
-        help: 'Experience in years',
+        help: 'Enter the year',
         min: 0,
         def: 0,
         required: true,


### PR DESCRIPTION
Changes:
- Rename "Experience" title to "Joined in" in Admin UI
- Rename help text from "Experience in years" to "Enter the year"
- Replace "[year]" with "Joined in [year]" for team members cards