### PR TITLE
Simplified version that doesn't break the deploy.

### DIFF
--- a/website/modules/@apostrophecms/seo/index.js
+++ b/website/modules/@apostrophecms/seo/index.js
@@ -1,3 +1,5 @@
+const gtmUtils = require('./lib/gtm-utils');
+
 module.exports = {
   improve: '@apostrophecms/seo',
   init(self) {
@@ -7,25 +9,6 @@ module.exports = {
     self.apos.template.prepend('head', '@apostrophecms/seo:metaHead');
   },
   components(self) {
-    /*
-     * Resolve GTM ID from global override or module options and validate it
-     */
-    const sanitizeGtmId = (id) => {
-      const value = String(id || '').trim();
-      if (/^gtm-[\da-z]+$/iu.test(value)) {
-        return value.toUpperCase();
-      }
-      return '';
-    };
-    const resolveGtmId = (req) => {
-      const fromGlobal = req?.data?.global?.seoGoogleTagManager;
-      const fromOptions = self.options?.googleTagManager?.id;
-      const candidate =
-        (fromGlobal && String(fromGlobal).trim()) ||
-        (fromOptions && String(fromOptions).trim());
-      return sanitizeGtmId(candidate);
-    };
-
     return {
       metaHead(req, data) {
         // Only on front-end page requests
@@ -38,7 +21,7 @@ module.exports = {
         if (!req?.data?.page) {
           return {};
         }
-        const gtmId = resolveGtmId(req);
+        const gtmId = gtmUtils.resolveGtmId(req, self.options);
         if (gtmId) {
           return { gtmId };
         }
@@ -48,7 +31,7 @@ module.exports = {
         if (!req?.data?.page) {
           return {};
         }
-        const gtmId = resolveGtmId(req);
+        const gtmId = gtmUtils.resolveGtmId(req, self.options);
         if (gtmId) {
           return { gtmId };
         }

--- a/website/modules/@apostrophecms/seo/lib/gtm-utils.js
+++ b/website/modules/@apostrophecms/seo/lib/gtm-utils.js
@@ -1,0 +1,25 @@
+module.exports = {
+  /**
+   * Sanitize and validate GTM ID
+   * Only allow valid GTM container IDs (e.g. "GTM-XXXX")
+   */
+  sanitizeGtmId(id) {
+    const value = String(id || '').trim();
+    if (/^gtm-[\da-z]+$/iu.test(value)) {
+      return value.toUpperCase();
+    }
+    return '';
+  },
+
+  /**
+   * Resolve GTM ID from global override or module options
+   */
+  resolveGtmId(req, options) {
+    const fromGlobal = req?.data?.global?.seoGoogleTagManager;
+    const fromOptions = options?.googleTagManager?.id;
+    const candidate =
+      (fromGlobal && String(fromGlobal).trim()) ||
+      (fromOptions && String(fromOptions).trim());
+    return this.sanitizeGtmId(candidate);
+  },
+};

--- a/website/modules/@apostrophecms/seo/views/gtmBody.html
+++ b/website/modules/@apostrophecms/seo/views/gtmBody.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ data.gtmId }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/website/modules/@apostrophecms/seo/views/gtmHead.html
+++ b/website/modules/@apostrophecms/seo/views/gtmHead.html
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ data.gtmId }}');</script>
+<!-- End Google Tag Manager -->

--- a/website/modules/@apostrophecms/seo/views/tagManagerBody.html
+++ b/website/modules/@apostrophecms/seo/views/tagManagerBody.html
@@ -1,6 +1,3 @@
 {% if data.gtmId %}
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ data.gtmId }}"
-height="0" width="0" style="display:none;visibility:hidden" title="Google Tag Manager"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
+{% render '@apostrophecms/seo:gtmBody', data %}
 {% endif %}

--- a/website/modules/@apostrophecms/seo/views/tagManagerHead.html
+++ b/website/modules/@apostrophecms/seo/views/tagManagerHead.html
@@ -1,9 +1,3 @@
 {% if data.gtmId %}
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','{{ data.gtmId }}');</script>
-<!-- End Google Tag Manager -->
+{% render '@apostrophecms/seo:gtmHead', data %}
 {% endif %}

--- a/website/package.json
+++ b/website/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@apostrophecms/form": "^1.4.2",
     "@apostrophecms/import-export": "^3.2.0",
-    "@apostrophecms/seo": "^1.3.1",
     "@barba/core": "^2.10.3",
     "abort-controller": "^3.0.0",
     "apostrophe": "^4.17.0",

--- a/website/views/layout.html
+++ b/website/views/layout.html
@@ -14,9 +14,11 @@
 {# ✅ Add favicon in the <head> section #}
 {% block extraHead %}
   <link rel="icon" href="{{ apos.asset.url('/modules/asset/favicon/favicon.ico') }}" type="image/x-icon">
+  {{ customSeoGtmHead(data) }}
 {% endblock %}
 
 {% block beforeMain %}
+  {{ customSeoGtmBody(data) }}
   <a class="sr-only" href="#main">Skip to content</a>
   <div
     class="bp-wrapper relative"


### PR DESCRIPTION
Fix the error during the Dev deploy
_______________
TypeError: self.prependNodes is not a function
    at Object.init (/app/node_modules/@apostrophecms/seo/index.js:20:10)
    at self.create (/app/node_modules/apostrophe/lib/moog.js:310:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async instantiateModules (/app/node_modules/apostrophe/index.js:669:32)
    at async apostrophe (/app/node_modules/apostrophe/index.js:319:5)
    at async /app/node_modules/apostrophe/index.js:160:17
    at async module.exports (/app/node_modules/apostrophe/index.js:159:16)
_______________

Get rid of the dependency on the contributed SEO package, simplify the approach to insert the scripts in the template. 