### PR TITLE
fix: Increase case studies pagination limit

### DIFF
--- a/website/modules/case-studies/index.js
+++ b/website/modules/case-studies/index.js
@@ -6,7 +6,7 @@ module.exports = {
     sort: {
       updatedAt: -1,
     },
-    perPage: 6,
+    perPage: 50,
     alias: 'caseStudy',
     shortcut: false,
   },


### PR DESCRIPTION
- Increase case studies pagination from 6 to 50 items per page

This fix addresses the limitation of showing only 6 case studies per page, which was causing poor user experience and requiring excessive pagination navigation.
