### PR TITLE
Quick fix: production URL if there is no in env.

### DIFF
--- a/website/app.js
+++ b/website/app.js
@@ -5,7 +5,7 @@ const { getEnv } = require('./utils/env');
 function createAposConfig() {
   return {
     shortName: 'apostrophe-site',
-    baseUrl: getEnv('BASE_URL'),
+    baseUrl: getEnv('BASE_URL') || 'https://speedandfunction.com',
 
     // Session configuration
     modules: {

--- a/website/app.js
+++ b/website/app.js
@@ -5,7 +5,7 @@ const { getEnv } = require('./utils/env');
 function createAposConfig() {
   return {
     shortName: 'apostrophe-site',
-    baseUrl: getEnv('BASE_URL') || 'https://speedandfunction.com',
+    baseUrl: process.env.BASE_URL || 'https://speedandfunction.com',
 
     // Session configuration
     modules: {

--- a/website/e2e/tests/screenshot-test.spec.js
+++ b/website/e2e/tests/screenshot-test.spec.js
@@ -7,7 +7,7 @@ test('Snapshot for Home Page', async ({ page }) => {
     height: 720,
   });
 
-  await page.goto(getEnv('BASE_URL'), {
+  await page.goto(process.env.BASE_URL || 'http://localhost:3000', {
     timeout: 60000,
     waitUntil: 'networkidle',
   });

--- a/website/e2e/tests/screenshot-test.spec.js
+++ b/website/e2e/tests/screenshot-test.spec.js
@@ -7,7 +7,7 @@ test('Snapshot for Home Page', async ({ page }) => {
     height: 720,
   });
 
-  await page.goto(process.env.BASE_URL || 'http://localhost:3000', {
+  await page.goto(getEnv('BASE_URL'), {
     timeout: 60000,
     waitUntil: 'networkidle',
   });


### PR DESCRIPTION
See conversation
https://spdfn.slack.com/archives/C2EKL870Q/p1755529615932599

We may lose BASE_URL inside the replacer endpoints.

The only way to check is to try that fix.