### PR TITLE
Disable Docker Scout PR comment to prevent accidental @mentions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -60,6 +60,7 @@ jobs:
           image: apostrophe-cms:test
           sarif-file: docker-scan-results.sarif
           only-severities: critical,high
+          write-comment: false
 
       - name: Upload scan results
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
We disabled Docker Scout auto-comments in CI by setting write-comment: false in the security-scan job.
This prevents scoped package names like @apostrophecms/... from being parsed as GitHub mentions and notifying unrelated users.
Security scanning is still active and results are still uploaded via SARIF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Disabled Docker Scout's automatic PR comments by configuring `write-comment: false` in the security-scan job within the CI workflow. This prevents scoped package names, such as `@apostrophecms/...`, from being incorrectly parsed as GitHub user mentions that would notify unrelated users. Security scanning remains fully active and SARIF results continue to be uploaded as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->