### PR TITLE
style fixes to homepage, removed tags from search

### DIFF
--- a/website/modules/@apostrophecms/search/views/index.html
+++ b/website/modules/@apostrophecms/search/views/index.html
@@ -67,7 +67,7 @@
           {% set resultUrl = doc._url %}
         {% elif doc.type == 'team-members' %}
           {% set meta = 'Team Member' %}
-          {% set resultUrl = '/meet-the-team' %}
+          {% set resultUrl = '/cases' %}
         {% elif doc.type == 'testimonials' %}
           {% set meta = 'Testimonial' %}
           {% set resultUrl = '/cases' %}
@@ -76,7 +76,7 @@
           {% set resultUrl = '/careers' %}
         {% elif doc.type == 'business-partner' %}
           {% set meta = 'Partner' %}
-          {% set resultUrl = '/about-us' %}
+          {% set resultUrl = '/cases' %}
         {% else %}
           {% set meta = 'Page' %}
           {% set resultUrl = doc._url %}

--- a/website/modules/cases-tags/index.js
+++ b/website/modules/cases-tags/index.js
@@ -9,6 +9,7 @@ module.exports = {
       title: 1,
     },
     shortcut: false,
+    searchable: false,
   },
   fields: {
     add: {

--- a/website/modules/categories/index.js
+++ b/website/modules/categories/index.js
@@ -4,6 +4,7 @@ module.exports = {
     label: 'Category',
     pluralLabel: 'Categories',
     shortcut: false,
+    searchable: false,
   },
   fields: {
     add: {

--- a/website/modules/home-simplified/public/css/home-simplified.css
+++ b/website/modules/home-simplified/public/css/home-simplified.css
@@ -217,7 +217,7 @@ body {
   font-size: 52px;
   font-weight: 700;
   line-height: 1.22;
-  letter-spacing: -1px;
+  letter-spacing: -2px;
   max-width: 1180px;
   text-wrap: balance;
   color: #141414;
@@ -462,7 +462,7 @@ svg.sicon {
   .ca-hero h1 {
     font-size: 26px;
     line-height: 1.24;
-    letter-spacing: -0.4px;
+    letter-spacing: -0.6px;
   }
 
   .ca-cue {

--- a/website/modules/team-members/index.js
+++ b/website/modules/team-members/index.js
@@ -5,6 +5,7 @@ module.exports = {
     label: 'Team Member',
     pluralLabel: 'Team Members',
     shortcut: false,
+    searchable: false,
     sort: {
       title: 1,
       updatedAt: -1,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated homepage hero typography with tighter letter spacing across desktop and mobile layouts. Removed search indexing for case study tags, categories, and team members, and routed team-member and business-partner search results to the shared `/cases` page. These changes simplify search behavior while aligning homepage heading styles with the updated visual design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->