### PR TITLE
updated homepage styles to option 5

### DIFF
--- a/website/modules/home-simplified/public/css/home-simplified.css
+++ b/website/modules/home-simplified/public/css/home-simplified.css
@@ -214,7 +214,7 @@ body {
 }
 
 .ca-hero h1 {
-  font-size: 52px;
+  font-size: 100px;
   font-weight: 700;
   line-height: 1.22;
   letter-spacing: -2px;

--- a/website/public/css/search-results/search-results.css
+++ b/website/public/css/search-results/search-results.css
@@ -279,7 +279,7 @@ body {
 }
 
 .sr-hero h1 {
-  font-size: 50px;
+  font-size: 38px;
   font-weight: 800;
   line-height: 1.2;
   color: #141414;
@@ -292,7 +292,7 @@ body {
   gap: 10px;
   font-size: 14px;
   font-weight: 800;
-  letter-spacing: 0.22em;
+  letter-spacing: 2.64px;
   text-transform: uppercase;
   color: #4A4A4A;
 }
@@ -317,11 +317,12 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 34px 0;
+  padding: 25px 0;
   border-bottom: 1px solid rgba(20,20,20,0.14);
   text-decoration: none;
   position: relative;
   gap: 28px;
+  min-height: 84px;
 }
 
 .sr-row-content {
@@ -335,13 +336,12 @@ body {
   font-size: 12px;
   font-weight: 700;
   color: #00897B;
-  letter-spacing: 0.1em;
+  letter-spacing: 1.2px;
 }
 
 .sr-title {
-  font-size: 30px;
-  font-weight: 700;
-  letter-spacing: -0.8px;
+  font-size: 24px;
+  font-weight: 600;
   color: #141414;
   transition: transform .3s cubic-bezier(.16,1,.3,1);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated homepage and search-results styling to match design option 5. The desktop homepage hero heading now uses a larger 100px font. Search results received refined typography and spacing, including a smaller hero heading, increased status letter spacing, adjusted row padding and minimum height, and revised category and title sizing, weight, and letter spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->