### PR TITLE
updated homepage styles to option 5-2

### DIFF
--- a/website/modules/home-simplified/views/page.html
+++ b/website/modules/home-simplified/views/page.html
@@ -21,7 +21,7 @@
 
     <div class="ca-hero">
       <div class="eyebrow"><span class="pulse"></span>The New Site Is On Its Way</div>
-      <h1>Software that<br class="h1-break"> carries <span class="grad">your</span><br class="h1-break"> <span class="grad">mission further.</span></h1>
+      <h1>Software that<br> carries <span class="grad">your</span><br> <span class="grad">mission further.</span></h1>
 
       <div class="ca-cue">
         <span class="cue-txt">For over a decade S&amp;F has partnered with purpose-driven companies to design, build, and scale products that matter.</span>

--- a/website/public/css/home-simplified/home-simplified.css
+++ b/website/public/css/home-simplified/home-simplified.css
@@ -174,10 +174,10 @@ body {
 }
 
 .ca-hero h1 {
-  font-size: 120px;
+  font-size: 100px;
   font-weight: 700;
   line-height: 0.9;
-  letter-spacing: -2.8px;
+  letter-spacing: -2px;
   vertical-align: middle;
   max-width: 1180px;
   text-wrap: balance;
@@ -431,7 +431,7 @@ svg.sicon {
   .ca-hero h1 {
     font-size: 40px;
     line-height: 0.9;
-    letter-spacing: -2.8px;
+    letter-spacing: -0.6px;
     max-width: none;
     padding-right: 4px;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the simplified homepage hero styling to match design option 5-2. The headline markup now uses standard line breaks without the `h1-break` class, while desktop typography uses a smaller font and refined letter spacing. Mobile letter spacing was also adjusted to provide more balanced headline rendering on screens up to 600px wide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->